### PR TITLE
fix: make ProcessAll() idempotent by skipping completed items

### DIFF
--- a/src/PromptBatchProcessor.cs
+++ b/src/PromptBatchProcessor.cs
@@ -552,6 +552,21 @@ namespace Prompt
                     continue;
                 }
 
+                // Skip items that already completed — makes ProcessAll() idempotent
+                if (item.Status == BatchItemStatus.Succeeded)
+                {
+                    completed++;
+                    succeeded++;
+                    ReportProgress(snapshot.Count, completed, succeeded, failed, item.Id);
+                    continue;
+                }
+                if (item.Status == BatchItemStatus.Skipped)
+                {
+                    completed++;
+                    ReportProgress(snapshot.Count, completed, succeeded, failed, item.Id);
+                    continue;
+                }
+
                 if (_filterFunc != null && !_filterFunc(item))
                 {
                     item.Status = BatchItemStatus.Skipped;


### PR DESCRIPTION
## Summary
ProcessAll() previously re-processed items that already succeeded, causing:
- Duplicate API costs
- Idempotency violations (side effects re-executed)
- Incorrect metrics (Attempts counter reset)

## Fix
Added status checks at the top of the processing loop to skip items with Succeeded or Skipped status. Only Pending and Failed items are now processed.

This makes RetryFailed() meaningful — it resets Failed→Pending for retry on next ProcessAll() call.

Fixes #32