### PR TITLE
fix: update cost estimator model catalog + fix build errors (fixes #49)

### DIFF
--- a/src/PromptCostEstimator.cs
+++ b/src/PromptCostEstimator.cs
@@ -198,6 +198,9 @@ namespace Prompt
         /// <summary>Maximum estimated output tokens allowed.</summary>
         public const int MaxOutputTokens = 1_000_000;
 
+        /// <summary>Catalog version date for built-in pricing data.</summary>
+        public const string CatalogVersion = "2026-03-09";
+
         /// <summary>Default estimated output tokens if not specified.</summary>
         public const int DefaultOutputTokens = 1_000;
 
@@ -428,18 +431,22 @@ namespace Prompt
             // OpenAI
             _models.Add(new ModelPricing("gpt-4o", "OpenAI", "GPT-4o", 2.50m, 10.00m, 128_000, 16_384));
             _models.Add(new ModelPricing("gpt-4o-mini", "OpenAI", "GPT-4o Mini", 0.15m, 0.60m, 128_000, 16_384));
+            _models.Add(new ModelPricing("gpt-4.5-preview", "OpenAI", "GPT-4.5 Preview", 75.00m, 150.00m, 128_000, 16_384));
             _models.Add(new ModelPricing("gpt-4-turbo", "OpenAI", "GPT-4 Turbo", 10.00m, 30.00m, 128_000, 4_096));
             _models.Add(new ModelPricing("o1", "OpenAI", "o1", 15.00m, 60.00m, 200_000, 100_000));
             _models.Add(new ModelPricing("o1-mini", "OpenAI", "o1-mini", 3.00m, 12.00m, 128_000, 65_536));
             _models.Add(new ModelPricing("o3-mini", "OpenAI", "o3-mini", 1.10m, 4.40m, 200_000, 100_000));
 
             // Anthropic
+            _models.Add(new ModelPricing("claude-4-sonnet", "Anthropic", "Claude 4 Sonnet", 3.00m, 15.00m, 200_000, 16_000));
+            _models.Add(new ModelPricing("claude-3.7-sonnet", "Anthropic", "Claude 3.7 Sonnet", 3.00m, 15.00m, 200_000, 128_000));
             _models.Add(new ModelPricing("claude-3-5-sonnet", "Anthropic", "Claude 3.5 Sonnet", 3.00m, 15.00m, 200_000, 8_192));
             _models.Add(new ModelPricing("claude-3-5-haiku", "Anthropic", "Claude 3.5 Haiku", 0.80m, 4.00m, 200_000, 8_192));
             _models.Add(new ModelPricing("claude-3-opus", "Anthropic", "Claude 3 Opus", 15.00m, 75.00m, 200_000, 4_096));
 
             // Google
-            _models.Add(new ModelPricing("gemini-2.0-flash", "Google", "Gemini 2.0 Flash", 0.10m, 0.40m, 1_000_000, 8_192));
+            _models.Add(new ModelPricing("gemini-2.5-pro", "Google", "Gemini 2.5 Pro", 1.25m, 10.00m, 1_048_576, 65_536));
+            _models.Add(new ModelPricing("gemini-2.0-flash", "Google", "Gemini 2.0 Flash", 0.10m, 0.40m, 1_048_576, 8_192));
             _models.Add(new ModelPricing("gemini-1.5-pro", "Google", "Gemini 1.5 Pro", 1.25m, 5.00m, 2_000_000, 8_192));
 
             // DeepSeek

--- a/src/PromptDebugger.cs
+++ b/src/PromptDebugger.cs
@@ -142,8 +142,7 @@ namespace Prompt
 
         // ── Regex timeout guard ──────────────────────────────────
 
-        /// <summary>Maximum allowed regex evaluation time.</summary>
-        private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(2);
+        // (Uses RegexTimeout defined at class top — 500ms)
 
         // ── Pre-compiled regex patterns for hot-path methods ────
 

--- a/tests/PromptCostEstimatorTests.cs
+++ b/tests/PromptCostEstimatorTests.cs
@@ -12,7 +12,7 @@ public class PromptCostEstimatorTests
     [Fact]
     public void Constructor_LoadsBuiltInModels()
     {
-        Assert.True(_estimator.ModelCount >= 10, "Should have at least 10 built-in models");
+        Assert.True(_estimator.ModelCount >= 15, $"Should have at least 15 built-in models, got {_estimator.ModelCount}");
     }
 
     [Fact]
@@ -22,10 +22,20 @@ public class PromptCostEstimatorTests
         Assert.NotEmpty(models);
     }
 
+    [Fact]
+    public void CatalogVersion_IsSet()
+    {
+        Assert.False(string.IsNullOrEmpty(PromptCostEstimator.CatalogVersion));
+    }
+
     [Theory]
     [InlineData("gpt-4o")]
     [InlineData("gpt-4o-mini")]
+    [InlineData("gpt-4.5-preview")]
+    [InlineData("claude-4-sonnet")]
+    [InlineData("claude-3.7-sonnet")]
     [InlineData("claude-3-5-sonnet")]
+    [InlineData("gemini-2.5-pro")]
     [InlineData("gemini-2.0-flash")]
     [InlineData("deepseek-v3")]
     public void GetModel_ReturnsKnownModels(string modelId)

--- a/tests/SerializationGuardsTests.cs
+++ b/tests/SerializationGuardsTests.cs
@@ -68,7 +68,7 @@ public class SerializationGuardsTests : IDisposable
         // Each emoji is 4 UTF-8 bytes — so MaxJsonPayloadBytes/4 emojis = at limit
         int emojiCount = SerializationGuards.MaxJsonPayloadBytes / 4;
         // One more emoji pushes over
-        var json = new string('🔥', emojiCount + 1);
+        var json = new string('\u2605', emojiCount + 1);
         Assert.Throws<InvalidOperationException>(
             () => SerializationGuards.ThrowIfPayloadTooLarge(json));
     }


### PR DESCRIPTION
Closes #49. Adds GPT-4.5 Preview, Claude 4 Sonnet, Claude 3.7 Sonnet, Gemini 2.5 Pro. Fixes Gemini 2.0 Flash context window. Adds CatalogVersion constant. Also fixes two pre-existing build errors (duplicate RegexTimeout, multi-byte char literal). All 81 cost estimator tests pass.