### PR TITLE
security: add regex timeout protection across 32 files (fixes #46)

### DIFF
--- a/src/PromptComplexityScorer.cs
+++ b/src/PromptComplexityScorer.cs
@@ -108,35 +108,35 @@ namespace Prompt
     {
         private static readonly Regex InstructionPattern = new(
             @"(?:^|\.\s+)(?:you\s+(?:must|should|will|need\s+to|are\s+to)|please\s+\w+|do\s+not|don't|never|always|ensure|make\s+sure|remember\s+to|be\s+sure\s+to|include|exclude|avoid|use\s+only|output|return|respond|answer|list|explain|analyze|compare|summarize|compute|calculate|generate|create|write|format|provide|give\s+me|show)",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         private static readonly Regex NestingPattern = new(
             @"\b(?:if\b|else\b|otherwise|unless|when\b|in\s+(?:that\s+)?case|except\s+(?:when|if)|provided\s+that|assuming|given\s+that|should\s+(?:the|this|it))\b",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         private static readonly Regex VariablePattern = new(
             @"(?:\{\{[\w.]+\}\}|\{[\w.]+\}|\[\[[\w.]+\]\]|<[\w.]+>|\$\{[\w.]+\}|<<[\w.]+>>)",
-            RegexOptions.Compiled);
+            RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         private static readonly Regex AmbiguityPattern = new(
             @"\b(?:maybe|perhaps|possibly|might|could\s+be|some(?:what|how)|sort\s+of|kind\s+of|roughly|approximately|etc\.?|and\s+so\s+on|or\s+something|as\s+(?:needed|appropriate|necessary)|if\s+(?:possible|applicable)|optionally|you\s+(?:may|can)\s+also)\b",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         private static readonly Regex DomainPattern = new(
             @"\b(?:API|SDK|REST|GraphQL|SQL|HIPAA|GDPR|PCI|WCAG|OWASP|OAuth|JWT|SAML|CORS|CRUD|ETL|CI/CD|TCP|UDP|DNS|SSL|TLS|ACID|CAP|regex|AST|IR|FFT|PCA|SVD|LSTM|GAN|BERT|transformer|embeddings|eigenvalue|gradient|backprop|tokenizer|attention\s+mechanism|fine-?tun|K-?means|SVM|AMT|AGI|W-?2|1099|Schedule\s+K|10-?K|EBITDA|P/?E\s+ratio|yield\s+curve|alpha|beta|sharpe|drawdown|VaR)\b",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         private static readonly Regex OutputFormatPattern = new(
             @"\b(?:JSON|XML|CSV|YAML|markdown|table|bullet\s*(?:point|list)|numbered\s+list|heading|format\s+(?:as|like|in)|schema|struct(?:ure)?d?\s+(?:output|response|format)|fields?:\s*\w+|columns?:\s*\w+)\b",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         private static readonly Regex ReasoningPattern = new(
             @"\b(?:step\s+by\s+step|chain\s+of\s+thought|think\s+(?:through|about|carefully)|reason(?:ing)?|analy[sz]e|compare\s+and\s+contrast|evaluate|weigh\s+(?:the\s+)?(?:pros|options|trade-?offs)|consider\s+(?:all|each|multiple)|break\s+(?:it\s+)?down|first\s*[,\.]\s*(?:then|next|second)|multi-?step|cross-?reference|synthesize|infer|deduce|derive)\b",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         private static readonly Regex ContextDependencyPattern = new(
             @"\b(?:the\s+(?:above|previous|following|given|provided|attached|uploaded)|based\s+on|referring\s+to|as\s+(?:mentioned|described|shown)|context|background|prior\s+(?:knowledge|conversation)|history|earlier|recall\s+that|remember\s+that|you\s+(?:already\s+)?know)\b",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         /// <summary>
         /// Scores the complexity of the given prompt text.

--- a/src/PromptComplianceChecker.cs
+++ b/src/PromptComplianceChecker.cs
@@ -444,7 +444,7 @@ namespace Prompt
                 {
                     var missing = sections.Where(s =>
                         !Regex.IsMatch(prompt, @$"(?:^|\n)\s*#+\s*{Regex.Escape(s)}\b",
-                            RegexOptions.IgnoreCase)
+                            RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500))
                         && !prompt.Contains(s, StringComparison.OrdinalIgnoreCase))
                         .ToList();
                     return missing.Count > 0
@@ -496,7 +496,7 @@ namespace Prompt
                         Severity = ComplianceSeverity.Warning,
                         Description = "Prompts should define the AI's role (e.g., 'You are...').",
                         Check = p => Regex.IsMatch(p, @"\b(you are|act as|role:|persona:)\b",
-                            RegexOptions.IgnoreCase) ? null
+                            RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)) ? null
                             : "Prompt should include a role definition (e.g., 'You are a...').",
                     },
                     new()
@@ -510,7 +510,7 @@ namespace Prompt
                             var m = Regex.Match(p,
                                 @"(sk-[a-zA-Z0-9]{20,}|AKIA[0-9A-Z]{16}|ghp_[a-zA-Z0-9]{36}|"
                                 + @"AIza[0-9A-Za-z\-_]{35}|xox[bpors]-[a-zA-Z0-9\-]{10,})",
-                                RegexOptions.None);
+                                RegexOptions.None, TimeSpan.FromMilliseconds(500));
                             return m.Success
                                 ? $"Potential API key/secret detected: {m.Value[..Math.Min(8, m.Value.Length)]}..."
                                 : null;
@@ -524,7 +524,7 @@ namespace Prompt
                         Description = "Prompts should not embed real email addresses.",
                         Check = p =>
                         {
-                            var m = Regex.Match(p, @"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}");
+                            var m = Regex.Match(p, @"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}", RegexOptions.None, TimeSpan.FromMilliseconds(500));
                             return m.Success
                                 ? $"Email address found in prompt: {m.Value}. Use a placeholder instead."
                                 : null;
@@ -538,7 +538,7 @@ namespace Prompt
                         Description = "Prompts should specify the expected output format.",
                         Check = p => Regex.IsMatch(p,
                             @"\b(respond|reply|output|return|format|answer)\b.{0,30}\b(json|xml|csv|markdown|list|table|bullet|numbered)\b",
-                            RegexOptions.IgnoreCase | RegexOptions.Singleline) ? null
+                            RegexOptions.IgnoreCase | RegexOptions.Singleline, TimeSpan.FromMilliseconds(500)) ? null
                             : "Consider specifying an output format for more predictable results.",
                     },
                 },
@@ -568,7 +568,7 @@ namespace Prompt
                                 + @"|DAN\s+mode|developer\s+mode|bypass\s+(?:safety|filter|content)"
                                 + @"|pretend\s+you\s+(?:have\s+no|don'?t\s+have)\s+(?:restrictions?|rules?|limits?)"
                                 + @"|act\s+as\s+if\s+you\s+have\s+no\s+(?:rules?|restrictions?|filters?))\b",
-                                RegexOptions.IgnoreCase);
+                                RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500));
                             return m.Success
                                 ? $"Jailbreak pattern detected: \"{m.Value}\"."
                                 : null;
@@ -586,7 +586,7 @@ namespace Prompt
                                 @"\b(how\s+to\s+(make|build|create)\s+(a\s+)?(bomb|weapon|explosive|virus|malware)"
                                 + @"|instructions?\s+for\s+(hacking|stealing|breaking\s+into)"
                                 + @"|generate\s+(hate\s+speech|harassment|threats))\b",
-                                RegexOptions.IgnoreCase);
+                                RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500));
                             return m.Success
                                 ? $"Potentially harmful content request detected: \"{m.Value}\"."
                                 : null;
@@ -602,11 +602,11 @@ namespace Prompt
                         {
                             bool hasSensitive = Regex.IsMatch(p,
                                 @"\b(race|gender|religion|ethnicity|disability|sexual\s+orientation|nationality|immigration)\b",
-                                RegexOptions.IgnoreCase);
+                                RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500));
                             if (!hasSensitive) return null;
                             bool hasFairness = Regex.IsMatch(p,
                                 @"\b(fair|unbiased|neutral|balanced|inclusive|equitable|objective)\b",
-                                RegexOptions.IgnoreCase);
+                                RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500));
                             return hasFairness ? null
                                 : "Prompt discusses sensitive topics — consider adding fairness/balance guidance.";
                         },
@@ -622,7 +622,7 @@ namespace Prompt
                             var m = Regex.Match(p,
                                 @"\b(pretend\s+to\s+be|impersonate|act\s+as|you\s+are)\s+"
                                 + @"(a\s+)?(doctor|lawyer|judge|police|officer|government|president|CEO|therapist|psychologist)\b",
-                                RegexOptions.IgnoreCase);
+                                RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500));
                             return m.Success
                                 ? $"Professional impersonation detected: \"{m.Value}\". "
                                   + "Use 'assist with' or 'provide information about' instead."
@@ -643,7 +643,7 @@ namespace Prompt
                                 + @"|what\s+(are|is)\s+your\s+(system\s+)?(prompt|instructions?)"
                                 + @"|output\s+(your|the)\s+(entire|full|complete)\s+(prompt|instructions?)"
                                 + @"|show\s+me\s+(your|the)\s+(hidden|secret|system))\b",
-                                RegexOptions.IgnoreCase);
+                                RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500));
                             return m.Success
                                 ? $"Data exfiltration pattern detected: \"{m.Value}\"."
                                 : null;
@@ -674,11 +674,11 @@ namespace Prompt
                             bool hasPII = Regex.IsMatch(p,
                                 @"\b(SSN|social\s+security|date\s+of\s+birth|credit\s+card|passport|driver'?s?\s+license"
                                 + @"|medical\s+record|patient\s+data|health\s+record)\b",
-                                RegexOptions.IgnoreCase);
+                                RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500));
                             if (!hasPII) return null;
                             bool hasGuidance = Regex.IsMatch(p,
                                 @"\b(redact|anonymize|mask|de-?identify|sanitize|do\s+not\s+(store|retain|log))\b",
-                                RegexOptions.IgnoreCase);
+                                RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500));
                             return hasGuidance ? null
                                 : "Prompt references personal data without data handling instructions. "
                                   + "Add guidance to redact, anonymize, or handle PII appropriately.";
@@ -692,9 +692,9 @@ namespace Prompt
                         Description = "Prompts must not contain real SSNs, credit card numbers, or similar.",
                         Check = p =>
                         {
-                            if (Regex.IsMatch(p, @"\b\d{3}-\d{2}-\d{4}\b"))
+                            if (Regex.IsMatch(p, @"\b\d{3}-\d{2}-\d{4}\b", RegexOptions.None, TimeSpan.FromMilliseconds(500)))
                                 return "Possible SSN detected in prompt. Use placeholder format (XXX-XX-XXXX).";
-                            if (Regex.IsMatch(p, @"\b(?:\d{4}[\s\-]?){4}\b"))
+                            if (Regex.IsMatch(p, @"\b(?:\d{4}[\s\-]?){4}\b", RegexOptions.None, TimeSpan.FromMilliseconds(500)))
                                 return "Possible credit card number detected. Use masked format.";
                             return null;
                         },
@@ -709,13 +709,13 @@ namespace Prompt
                         {
                             bool isMedical = Regex.IsMatch(p,
                                 @"\b(?:diagnos\w*|symptom\w*|treatment\w*|medication\w*|prescri\w*|medical\s+advice|health\s+condition)",
-                                RegexOptions.IgnoreCase);
+                                RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500));
                             if (!isMedical) return null;
                             bool hasDisclaimer = Regex.IsMatch(p,
                                 @"\b(not\s+(a\s+)?(substitute|replacement)\s+for\s+(professional|medical)"
                                 + @"|consult\s+(a|your)\s+(doctor|physician|healthcare)"
                                 + @"|disclaimer|for\s+informational\s+purposes?\s+only)\b",
-                                RegexOptions.IgnoreCase);
+                                RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500));
                             return hasDisclaimer ? null
                                 : "Medical topic detected without disclaimer. Add: 'This is not a substitute for professional medical advice.'";
                         },
@@ -731,12 +731,12 @@ namespace Prompt
                             bool isFinancial = Regex.IsMatch(p,
                                 @"\b(?:invest(?:ment|ing)?|stock\s+(?:pick|recommend)\w*|financial\s+advi[cs]e"
                                 + @"|portfolio|trading\s+strateg\w*|buy\s+or\s+sell)\b",
-                                RegexOptions.IgnoreCase);
+                                RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500));
                             if (!isFinancial) return null;
                             bool hasDisclaimer = Regex.IsMatch(p,
                                 @"\b(not\s+financial\s+advice|consult\s+(a|your)\s+(financial|advisor)"
                                 + @"|for\s+informational\s+purposes?\s+only|do\s+your\s+own\s+research)\b",
-                                RegexOptions.IgnoreCase);
+                                RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500));
                             return hasDisclaimer ? null
                                 : "Financial topic detected without disclaimer. Add: 'This is not financial advice.'";
                         },
@@ -751,11 +751,11 @@ namespace Prompt
                         {
                             bool isGDPR = Regex.IsMatch(p,
                                 @"\b(GDPR|EU\s+user|European\s+data|data\s+subject|right\s+to\s+(be\s+)?forgot)\b",
-                                RegexOptions.IgnoreCase);
+                                RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500));
                             if (!isGDPR) return null;
                             bool hasConsent = Regex.IsMatch(p,
                                 @"\b(consent|lawful\s+basis|legitimate\s+interest|data\s+processing\s+agreement)\b",
-                                RegexOptions.IgnoreCase);
+                                RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500));
                             return hasConsent ? null
                                 : "GDPR-related prompt should reference consent or lawful basis for processing.";
                         },

--- a/src/PromptConditional.cs
+++ b/src/PromptConditional.cs
@@ -288,14 +288,14 @@ namespace Prompt
             var errors = new List<string>();
 
             // Check balanced if/endif
-            int ifCount = Regex.Matches(template, @"\{\{#if\s").Count;
-            int endifCount = Regex.Matches(template, @"\{\{/if\}\}").Count;
+            int ifCount = Regex.Matches(template, @"\{\{#if\s", RegexOptions.None, TimeSpan.FromMilliseconds(500)).Count;
+            int endifCount = Regex.Matches(template, @"\{\{/if\}\}", RegexOptions.None, TimeSpan.FromMilliseconds(500)).Count;
             if (ifCount != endifCount)
                 errors.Add($"Mismatched if/endif: {ifCount} opening vs {endifCount} closing tags.");
 
             // Check balanced switch/endswitch
-            int switchCount = Regex.Matches(template, @"\{\{#switch\s").Count;
-            int endSwitchCount = Regex.Matches(template, @"\{\{/switch\}\}").Count;
+            int switchCount = Regex.Matches(template, @"\{\{#switch\s", RegexOptions.None, TimeSpan.FromMilliseconds(500)).Count;
+            int endSwitchCount = Regex.Matches(template, @"\{\{/switch\}\}", RegexOptions.None, TimeSpan.FromMilliseconds(500)).Count;
             if (switchCount != endSwitchCount)
                 errors.Add($"Mismatched switch/endswitch: {switchCount} opening vs {endSwitchCount} closing tags.");
 

--- a/src/PromptContextCompressor.cs
+++ b/src/PromptContextCompressor.cs
@@ -489,11 +489,11 @@ namespace Prompt
             }
 
             // Bonus for code blocks
-            bool hasCode = Regex.IsMatch(content, @"```[\s\S]*?```");
+            bool hasCode = Regex.IsMatch(content, @"```[\s\S]*?```", RegexOptions.None, TimeSpan.FromMilliseconds(500));
             double codeBonus = hasCode && _options.PreserveCodeBlocks ? 0.2 : 0;
 
             // Bonus for URLs
-            bool hasUrl = Regex.IsMatch(content, @"https?://\S+");
+            bool hasUrl = Regex.IsMatch(content, @"https?://\S+", RegexOptions.None, TimeSpan.FromMilliseconds(500));
             double urlBonus = hasUrl && _options.PreserveUrls ? 0.15 : 0;
 
             double score = _options.RecencyWeight * recency
@@ -577,7 +577,7 @@ namespace Prompt
         private static string NormalizeForComparison(string s)
         {
             s = s.ToLowerInvariant().Trim();
-            s = Regex.Replace(s, @"\s+", " ");
+            s = Regex.Replace(s, @"\s+", " ", RegexOptions.None, TimeSpan.FromMilliseconds(500));
             return s;
         }
 

--- a/src/PromptDebugger.cs
+++ b/src/PromptDebugger.cs
@@ -148,15 +148,15 @@ namespace Prompt
 
         private static readonly Regex ImperativePattern = new(
             @"^\s*(list|explain|describe|summarize|write|create|generate|analyze|compare|translate|convert|extract|find|show|tell|give|provide)\b",
-            RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled);
+            RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         private static readonly Regex InstructionWordsPattern = new(
             @"\b(must|should|always|never|ensure|make\s+sure|required|important|critical|do\s+not|don'?t)\b",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         private static readonly Regex CapsPattern = new(
             @"\b[A-Z]{4,}\b",
-            RegexOptions.Compiled);
+            RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         /// <summary>
         /// Safe regex match with timeout protection to prevent ReDoS.
@@ -181,7 +181,7 @@ namespace Prompt
             }
             catch (RegexMatchTimeoutException)
             {
-                return Regex.Matches("", "x"); // empty matches
+                return Regex.Matches("", "x", RegexOptions.None, TimeSpan.FromMilliseconds(500)); // empty matches
             }
         }
 
@@ -412,7 +412,7 @@ namespace Prompt
         {
             var words = prompt.Split(new[] { ' ', '\t', '\n', '\r' },
                 StringSplitOptions.RemoveEmptyEntries);
-            var sentences = Regex.Split(prompt, @"(?<=[.!?])\s+");
+            var sentences = Regex.Split(prompt, @"(?<=[.!?])\s+", RegexOptions.None, TimeSpan.FromMilliseconds(500));
             var lines = prompt.Split('\n');
 
             report.WordCount = words.Length;
@@ -465,7 +465,7 @@ namespace Prompt
             }
 
             // Check for template placeholders that weren't filled
-            var unfilled = Regex.Matches(prompt, @"\{\{[^}]+\}\}");
+            var unfilled = Regex.Matches(prompt, @"\{\{[^}]+\}\}", RegexOptions.None, TimeSpan.FromMilliseconds(500));
             if (unfilled.Count > 0)
             {
                 var names = unfilled.Cast<Match>().Select(m => m.Value).Distinct().ToList();

--- a/src/PromptDependencyGraph.cs
+++ b/src/PromptDependencyGraph.cs
@@ -648,7 +648,7 @@ namespace Prompt
             if (!_nodes.ContainsKey(nodeId))
                 throw new ArgumentException($"Node '{nodeId}' not found.", nameof(nodeId));
 
-            var matches = Regex.Matches(templateText, @"\{\{(\w+)\}\}");
+            var matches = Regex.Matches(templateText, @"\{\{(\w+)\}\}", RegexOptions.None, TimeSpan.FromMilliseconds(500));
             foreach (Match match in matches)
             {
                 string refId = match.Groups[1].Value;

--- a/src/PromptDocGenerator.cs
+++ b/src/PromptDocGenerator.cs
@@ -164,11 +164,11 @@ namespace Prompt
     /// </summary>
     public class PromptDocGenerator
     {
-        private static readonly Regex VariablePattern = new(@"\{\{(\w+)\}\}", RegexOptions.Compiled);
-        private static readonly Regex HeadingPattern = new(@"^(#{1,6})\s+(.+)$", RegexOptions.Multiline | RegexOptions.Compiled);
-        private static readonly Regex MetadataPattern = new(@"^@(\w+)\s*:\s*(.+)$", RegexOptions.Multiline | RegexOptions.Compiled);
-        private static readonly Regex ConditionalPattern = new(@"\{\{#if\s+(\w+)\}\}.*?\{\{/if\}\}", RegexOptions.Singleline | RegexOptions.Compiled);
-        private static readonly Regex LoopPattern = new(@"\{\{#each\s+(\w+)\}\}.*?\{\{/each\}\}", RegexOptions.Singleline | RegexOptions.Compiled);
+        private static readonly Regex VariablePattern = new(@"\{\{(\w+)\}\}", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
+        private static readonly Regex HeadingPattern = new(@"^(#{1,6})\s+(.+)$", RegexOptions.Multiline | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
+        private static readonly Regex MetadataPattern = new(@"^@(\w+)\s*:\s*(.+)$", RegexOptions.Multiline | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
+        private static readonly Regex ConditionalPattern = new(@"\{\{#if\s+(\w+)\}\}.*?\{\{/if\}\}", RegexOptions.Singleline | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
+        private static readonly Regex LoopPattern = new(@"\{\{#each\s+(\w+)\}\}.*?\{\{/each\}\}", RegexOptions.Singleline | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         private readonly DocGeneratorOptions _options;
 
@@ -581,7 +581,7 @@ namespace Prompt
                 var doc = catalog.Prompts[i];
                 string md = ToMarkdown(doc);
                 // Bump heading levels for catalog embedding
-                md = Regex.Replace(md, @"^(#{1,5})", "$1#", RegexOptions.Multiline);
+                md = Regex.Replace(md, @"^(#{1,5})", "$1#", RegexOptions.Multiline, TimeSpan.FromMilliseconds(500));
                 sb.Append(md);
             }
 

--- a/src/PromptEnvironmentManager.cs
+++ b/src/PromptEnvironmentManager.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 namespace Prompt
 {
     using System.Text.Json;
@@ -51,7 +52,7 @@ namespace Prompt
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Environment name cannot be empty.", nameof(name));
 
-            if (!System.Text.RegularExpressions.Regex.IsMatch(name, @"^[a-zA-Z0-9_-]+$"))
+            if (!System.Text.RegularExpressions.Regex.IsMatch(name, @"^[a-zA-Z0-9_-]+$", RegexOptions.None, TimeSpan.FromMilliseconds(500)))
                 throw new ArgumentException(
                     "Environment name must contain only letters, digits, hyphens, and underscores.",
                     nameof(name));

--- a/src/PromptExplainer.cs
+++ b/src/PromptExplainer.cs
@@ -219,7 +219,7 @@ namespace Prompt
             var results = new List<ExplainerTechnique>();
             foreach (var (pattern, name, desc) in TechniquePatterns)
             {
-                var matches = Regex.Matches(prompt, pattern);
+                var matches = Regex.Matches(prompt, pattern, RegexOptions.None, TimeSpan.FromMilliseconds(500));
                 if (matches.Count > 0)
                 {
                     var best = matches[0];
@@ -254,7 +254,7 @@ namespace Prompt
 
                 foreach (var (pattern, sectionType, explTemplate) in SectionPatterns)
                 {
-                    if (Regex.IsMatch(line, pattern))
+                    if (Regex.IsMatch(line, pattern, RegexOptions.None, TimeSpan.FromMilliseconds(500)))
                     {
                         matchedType = sectionType;
                         explanation = explTemplate;
@@ -263,7 +263,7 @@ namespace Prompt
                 }
 
                 // Also detect markdown-style headers as section boundaries
-                if (matchedType == null && Regex.IsMatch(line, @"^#{1,3}\s+\S"))
+                if (matchedType == null && Regex.IsMatch(line, @"^#{1,3}\s+\S", RegexOptions.None, TimeSpan.FromMilliseconds(500)))
                 {
                     matchedType = "Heading";
                     explanation = "Section header: " + line.TrimStart('#', ' ');
@@ -375,7 +375,7 @@ namespace Prompt
             }
 
             // Check for excessive negative constraints
-            var negCount = Regex.Matches(prompt, @"(?i)\b(do not|don'?t|never|must not)\b").Count;
+            var negCount = Regex.Matches(prompt, @"(?i)\b(do not|don'?t|never|must not)\b", RegexOptions.None, TimeSpan.FromMilliseconds(500)).Count;
             if (negCount > 5)
             {
                 suggestions.Add(new ExplainerSuggestion
@@ -387,7 +387,7 @@ namespace Prompt
             }
 
             // Check for ambiguous pronouns
-            var pronounMatches = Regex.Matches(prompt, @"(?i)\b(it|this|that|these|those|they)\b(?!\s+(?:is|are|was|were|should|must|will|can))");
+            var pronounMatches = Regex.Matches(prompt, @"(?i)\b(it|this|that|these|those|they)\b(?!\s+(?:is|are|was|were|should|must|will|can))", RegexOptions.None, TimeSpan.FromMilliseconds(500));
             if (pronounMatches.Count > 8)
             {
                 suggestions.Add(new ExplainerSuggestion
@@ -400,7 +400,7 @@ namespace Prompt
 
             // Suggest chain-of-thought for complex tasks
             if (!techniques.Any(t => t.Name == "Chain-of-Thought") &&
-                (Regex.IsMatch(prompt, @"(?i)\b(analyze|compare|evaluate|explain|solve|debug|reason)\b")))
+                (Regex.IsMatch(prompt, @"(?i)\b(analyze|compare|evaluate|explain|solve|debug|reason)\b", RegexOptions.None, TimeSpan.FromMilliseconds(500))))
             {
                 suggestions.Add(new ExplainerSuggestion
                 {
@@ -412,7 +412,7 @@ namespace Prompt
 
             // Check for no examples on classification/extraction tasks
             if (!techniques.Any(t => t.Name == "Few-Shot") &&
-                Regex.IsMatch(prompt, @"(?i)\b(classify|categorize|extract|identify|label|tag)\b"))
+                Regex.IsMatch(prompt, @"(?i)\b(classify|categorize|extract|identify|label|tag)\b", RegexOptions.None, TimeSpan.FromMilliseconds(500)))
             {
                 suggestions.Add(new ExplainerSuggestion
                 {

--- a/src/PromptFingerprint.cs
+++ b/src/PromptFingerprint.cs
@@ -155,8 +155,8 @@ namespace Prompt
     public class PromptFingerprintGenerator
     {
         // Pre-compiled regexes — avoids re-parsing the pattern on every Normalize() call.
-        private static readonly Regex WhitespaceRegex = new(@"\s+", RegexOptions.Compiled);
-        private static readonly Regex PunctuationRegex = new(@"[^\w\s]", RegexOptions.Compiled);
+        private static readonly Regex WhitespaceRegex = new(@"\s+", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
+        private static readonly Regex PunctuationRegex = new(@"[^\w\s]", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         private static readonly HashSet<string> DefaultStopWords = new(StringComparer.OrdinalIgnoreCase)
         {

--- a/src/PromptFuzzer.cs
+++ b/src/PromptFuzzer.cs
@@ -119,7 +119,7 @@ namespace Prompt
     {
         private static readonly Random Rng = new();
 
-        private static readonly Regex WordBoundary = new(@"\b(\w+)\b", RegexOptions.Compiled);
+        private static readonly Regex WordBoundary = new(@"\b(\w+)\b", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         // Common synonym pairs for fuzzing
         private static readonly Dictionary<string, string[]> Synonyms = new(StringComparer.OrdinalIgnoreCase)

--- a/src/PromptGrammarValidator.cs
+++ b/src/PromptGrammarValidator.cs
@@ -593,7 +593,7 @@ namespace Prompt
             try
             {
                 var opts = rule.IgnoreCase ? RegexOptions.IgnoreCase : RegexOptions.None;
-                if (Regex.IsMatch(response, rule.Pattern, opts))
+                if (Regex.IsMatch(response, rule.Pattern, opts, TimeSpan.FromMilliseconds(500)))
                     return null;
                 return MakeViolation(rule, "Response does not match pattern.", rule.Pattern, Truncate(response, 100));
             }
@@ -728,7 +728,7 @@ namespace Prompt
             {
                 // Look for markdown headings or "SECTION:" patterns
                 var headingPattern = $@"(?m)^#+\s+{Regex.Escape(section)}|^{Regex.Escape(section)}\s*[:：]";
-                if (!Regex.IsMatch(response, headingPattern, RegexOptions.IgnoreCase))
+                if (!Regex.IsMatch(response, headingPattern, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)))
                     return MakeViolation(rule, $"Missing required section: {section}",
                         section, "not found");
             }
@@ -768,7 +768,7 @@ namespace Prompt
             }
 
             // Try extracting from markdown code block
-            var match = Regex.Match(text, @"```(?:json)?\s*\n?([\s\S]*?)\n?\s*```");
+            var match = Regex.Match(text, @"```(?:json)?\s*\n?([\s\S]*?)\n?\s*```", RegexOptions.None, TimeSpan.FromMilliseconds(500));
             if (match.Success)
             {
                 var inner = match.Groups[1].Value.Trim();

--- a/src/PromptGuard.cs
+++ b/src/PromptGuard.cs
@@ -862,7 +862,7 @@ namespace Prompt
             // Check the template text itself for static injection patterns
             // (patterns not inside {{variables}})
             string templateWithoutVars = Regex.Replace(
-                template.Template, @"\{\{\w+\}\}", "PLACEHOLDER");
+                template.Template, @"\{\{\w+\}\}", "PLACEHOLDER", RegexOptions.None, TimeSpan.FromMilliseconds(500));
             if (DetectInjection(templateWithoutVars))
             {
                 warnings.Add(

--- a/src/PromptInterpolator.cs
+++ b/src/PromptInterpolator.cs
@@ -106,7 +106,7 @@ namespace Prompt
 
             _cachedPattern = new Regex(
                 Regex.Escape(_openDelimiter) + @"\s*(.+?)\s*" + Regex.Escape(_closeDelimiter),
-                RegexOptions.Compiled);
+                RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
             _cachedPatternKey = key;
             return _cachedPattern;
         }
@@ -446,8 +446,8 @@ namespace Prompt
         private static string Slugify(string input)
         {
             var slug = input.ToLowerInvariant().Trim();
-            slug = Regex.Replace(slug, @"[^a-z0-9\s-]", "");
-            slug = Regex.Replace(slug, @"[\s-]+", "-");
+            slug = Regex.Replace(slug, @"[^a-z0-9\s-]", "", RegexOptions.None, TimeSpan.FromMilliseconds(500));
+            slug = Regex.Replace(slug, @"[\s-]+", "-", RegexOptions.None, TimeSpan.FromMilliseconds(500));
             return slug.Trim('-');
         }
 

--- a/src/PromptMerger.cs
+++ b/src/PromptMerger.cs
@@ -145,11 +145,11 @@ namespace Prompt
 
         private static readonly Regex HeadingPattern = new(
             @"^(?:#{1,4}\s+(.+)|([A-Z][A-Z\s]{2,}):)\s*$",
-            RegexOptions.Multiline | RegexOptions.Compiled);
+            RegexOptions.Multiline | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         private static readonly Regex VariablePattern = new(
             @"\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}",
-            RegexOptions.Compiled);
+            RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         /// <summary>Merges multiple prompts into a single cohesive prompt.</summary>
         public MergeResult Merge(IEnumerable<string> prompts, MergeOptions? options = null)
@@ -424,7 +424,7 @@ namespace Prompt
         }
 
         private static string NormalizeSectionName(string name)
-            => Regex.Replace(name.Trim().ToLowerInvariant(), @"\s+", " ");
+            => Regex.Replace(name.Trim().ToLowerInvariant(), @"\s+", " ", RegexOptions.None, TimeSpan.FromMilliseconds(500));
 
         private (string merged, int removed) ResolveSectionConflict(List<MergedSection> group, MergeOptions opts)
         {

--- a/src/PromptMigrationAssistant.cs
+++ b/src/PromptMigrationAssistant.cs
@@ -377,36 +377,36 @@ namespace Prompt
         private static readonly (Regex Pattern, LlmProvider Provider, double Weight, string Signal)[] DetectionPatterns =
         {
             // OpenAI signals
-            (new Regex(@"\bChatGPT\b", RegexOptions.IgnoreCase), LlmProvider.OpenAI, 0.8, "References ChatGPT"),
-            (new Regex(@"\bGPT-?[34]\b", RegexOptions.IgnoreCase), LlmProvider.OpenAI, 0.9, "References GPT model"),
-            (new Regex(@"\bOpenAI\b", RegexOptions.IgnoreCase), LlmProvider.OpenAI, 0.7, "References OpenAI"),
-            (new Regex(@"response_format.*json", RegexOptions.IgnoreCase), LlmProvider.OpenAI, 0.6, "OpenAI JSON mode syntax"),
-            (new Regex(@"\bDALL[·\-]?E\b", RegexOptions.IgnoreCase), LlmProvider.OpenAI, 0.7, "References DALL-E"),
-            (new Regex(@"\bseed\s*[:=]\s*\d+", RegexOptions.IgnoreCase), LlmProvider.OpenAI, 0.3, "Seed parameter (OpenAI convention)"),
+            (new Regex(@"\bChatGPT\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), LlmProvider.OpenAI, 0.8, "References ChatGPT"),
+            (new Regex(@"\bGPT-?[34]\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), LlmProvider.OpenAI, 0.9, "References GPT model"),
+            (new Regex(@"\bOpenAI\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), LlmProvider.OpenAI, 0.7, "References OpenAI"),
+            (new Regex(@"response_format.*json", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), LlmProvider.OpenAI, 0.6, "OpenAI JSON mode syntax"),
+            (new Regex(@"\bDALL[·\-]?E\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), LlmProvider.OpenAI, 0.7, "References DALL-E"),
+            (new Regex(@"\bseed\s*[:=]\s*\d+", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), LlmProvider.OpenAI, 0.3, "Seed parameter (OpenAI convention)"),
 
             // Anthropic signals
-            (new Regex(@"\bClaude\b", RegexOptions.IgnoreCase), LlmProvider.Anthropic, 0.9, "References Claude"),
-            (new Regex(@"\bAnthropic\b", RegexOptions.IgnoreCase), LlmProvider.Anthropic, 0.8, "References Anthropic"),
-            (new Regex(@"\bHuman:\s", RegexOptions.None), LlmProvider.Anthropic, 0.7, "Uses Human: turn marker"),
-            (new Regex(@"\bAssistant:\s", RegexOptions.None), LlmProvider.Anthropic, 0.5, "Uses Assistant: turn marker"),
-            (new Regex(@"<thinking>", RegexOptions.IgnoreCase), LlmProvider.Anthropic, 0.6, "Uses thinking XML tags"),
-            (new Regex(@"</?(?:instructions|context|example|output|document|user_input|response)>", RegexOptions.IgnoreCase), LlmProvider.Anthropic, 0.5, "Uses XML section tags (Anthropic convention)"),
+            (new Regex(@"\bClaude\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), LlmProvider.Anthropic, 0.9, "References Claude"),
+            (new Regex(@"\bAnthropic\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), LlmProvider.Anthropic, 0.8, "References Anthropic"),
+            (new Regex(@"\bHuman:\s", RegexOptions.None, TimeSpan.FromMilliseconds(500)), LlmProvider.Anthropic, 0.7, "Uses Human: turn marker"),
+            (new Regex(@"\bAssistant:\s", RegexOptions.None, TimeSpan.FromMilliseconds(500)), LlmProvider.Anthropic, 0.5, "Uses Assistant: turn marker"),
+            (new Regex(@"<thinking>", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), LlmProvider.Anthropic, 0.6, "Uses thinking XML tags"),
+            (new Regex(@"</?(?:instructions|context|example|output|document|user_input|response)>", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), LlmProvider.Anthropic, 0.5, "Uses XML section tags (Anthropic convention)"),
 
             // Google signals
-            (new Regex(@"\bGemini\b", RegexOptions.IgnoreCase), LlmProvider.Google, 0.9, "References Gemini"),
-            (new Regex(@"\bGoogle\s+AI\b", RegexOptions.IgnoreCase), LlmProvider.Google, 0.7, "References Google AI"),
-            (new Regex(@"\bsystem_instruction\b", RegexOptions.IgnoreCase), LlmProvider.Google, 0.6, "Uses system_instruction"),
-            (new Regex(@"\bharm_category\b", RegexOptions.IgnoreCase), LlmProvider.Google, 0.5, "References harm categories"),
+            (new Regex(@"\bGemini\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), LlmProvider.Google, 0.9, "References Gemini"),
+            (new Regex(@"\bGoogle\s+AI\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), LlmProvider.Google, 0.7, "References Google AI"),
+            (new Regex(@"\bsystem_instruction\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), LlmProvider.Google, 0.6, "Uses system_instruction"),
+            (new Regex(@"\bharm_category\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), LlmProvider.Google, 0.5, "References harm categories"),
 
             // Meta/Llama signals
-            (new Regex(@"\bLlama\s*[23]?\b", RegexOptions.IgnoreCase), LlmProvider.Meta, 0.8, "References Llama model"),
-            (new Regex(@"\[INST\]", RegexOptions.None), LlmProvider.Meta, 0.7, "Uses [INST] markers"),
-            (new Regex(@"<<SYS>>", RegexOptions.None), LlmProvider.Meta, 0.9, "Uses <<SYS>> system tags"),
-            (new Regex(@"\[/INST\]", RegexOptions.None), LlmProvider.Meta, 0.7, "Uses [/INST] markers"),
+            (new Regex(@"\bLlama\s*[23]?\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), LlmProvider.Meta, 0.8, "References Llama model"),
+            (new Regex(@"\[INST\]", RegexOptions.None, TimeSpan.FromMilliseconds(500)), LlmProvider.Meta, 0.7, "Uses [INST] markers"),
+            (new Regex(@"<<SYS>>", RegexOptions.None, TimeSpan.FromMilliseconds(500)), LlmProvider.Meta, 0.9, "Uses <<SYS>> system tags"),
+            (new Regex(@"\[/INST\]", RegexOptions.None, TimeSpan.FromMilliseconds(500)), LlmProvider.Meta, 0.7, "Uses [/INST] markers"),
 
             // Mistral signals
-            (new Regex(@"\bMistral\b", RegexOptions.IgnoreCase), LlmProvider.Mistral, 0.8, "References Mistral"),
-            (new Regex(@"\bMixtral\b", RegexOptions.IgnoreCase), LlmProvider.Mistral, 0.7, "References Mixtral"),
+            (new Regex(@"\bMistral\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), LlmProvider.Mistral, 0.8, "References Mistral"),
+            (new Regex(@"\bMixtral\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), LlmProvider.Mistral, 0.7, "References Mixtral"),
         };
 
         // Migration rules: (source, target, pattern, replacement_fn, category, severity, description)
@@ -424,108 +424,108 @@ namespace Prompt
         {
             // OpenAI → Anthropic: ChatGPT references
             new(LlmProvider.OpenAI, LlmProvider.Anthropic,
-                new Regex(@"\bChatGPT\b", RegexOptions.IgnoreCase),
+                new Regex(@"\bChatGPT\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)),
                 _ => "Claude", MigrationCategory.RoleConvention, MigrationSeverity.Warning,
                 "Replace ChatGPT references with Claude"),
 
             // OpenAI → Anthropic: GPT model references
             new(LlmProvider.OpenAI, LlmProvider.Anthropic,
-                new Regex(@"\bGPT-?[34][^\s]*\b", RegexOptions.IgnoreCase),
+                new Regex(@"\bGPT-?[34][^\s]*\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)),
                 _ => "Claude", MigrationCategory.RoleConvention, MigrationSeverity.Info,
                 "Replace GPT model references with Claude"),
 
             // OpenAI → Google: ChatGPT references
             new(LlmProvider.OpenAI, LlmProvider.Google,
-                new Regex(@"\bChatGPT\b", RegexOptions.IgnoreCase),
+                new Regex(@"\bChatGPT\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)),
                 _ => "Gemini", MigrationCategory.RoleConvention, MigrationSeverity.Warning,
                 "Replace ChatGPT references with Gemini"),
 
             // Anthropic → OpenAI: Claude references
             new(LlmProvider.Anthropic, LlmProvider.OpenAI,
-                new Regex(@"\bClaude\b"), _ => "ChatGPT",
+                new Regex(@"\bClaude\b", RegexOptions.None, TimeSpan.FromMilliseconds(500)), _ => "ChatGPT",
                 MigrationCategory.RoleConvention, MigrationSeverity.Warning,
                 "Replace Claude references with ChatGPT"),
 
             // Anthropic → Google: Claude references
             new(LlmProvider.Anthropic, LlmProvider.Google,
-                new Regex(@"\bClaude\b"), _ => "Gemini",
+                new Regex(@"\bClaude\b", RegexOptions.None, TimeSpan.FromMilliseconds(500)), _ => "Gemini",
                 MigrationCategory.RoleConvention, MigrationSeverity.Warning,
                 "Replace Claude references with Gemini"),
 
             // Google → OpenAI: Gemini references
             new(LlmProvider.Google, LlmProvider.OpenAI,
-                new Regex(@"\bGemini\b", RegexOptions.IgnoreCase), _ => "ChatGPT",
+                new Regex(@"\bGemini\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), _ => "ChatGPT",
                 MigrationCategory.RoleConvention, MigrationSeverity.Warning,
                 "Replace Gemini references with ChatGPT"),
 
             // Google → Anthropic: Gemini references
             new(LlmProvider.Google, LlmProvider.Anthropic,
-                new Regex(@"\bGemini\b", RegexOptions.IgnoreCase), _ => "Claude",
+                new Regex(@"\bGemini\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)), _ => "Claude",
                 MigrationCategory.RoleConvention, MigrationSeverity.Warning,
                 "Replace Gemini references with Claude"),
 
             // Meta → OpenAI: [INST] markers
             new(LlmProvider.Meta, LlmProvider.OpenAI,
-                new Regex(@"\[/?INST\]"), _ => "",
+                new Regex(@"\[/?INST\]", RegexOptions.None, TimeSpan.FromMilliseconds(500)), _ => "",
                 MigrationCategory.Formatting, MigrationSeverity.Warning,
                 "Remove [INST]/[/INST] markers (not used by OpenAI)"),
 
             // Meta → Anthropic: [INST] markers
             new(LlmProvider.Meta, LlmProvider.Anthropic,
-                new Regex(@"\[/?INST\]"), _ => "",
+                new Regex(@"\[/?INST\]", RegexOptions.None, TimeSpan.FromMilliseconds(500)), _ => "",
                 MigrationCategory.Formatting, MigrationSeverity.Warning,
                 "Remove [INST]/[/INST] markers (not used by Anthropic)"),
 
             // Meta → Google: [INST] markers
             new(LlmProvider.Meta, LlmProvider.Google,
-                new Regex(@"\[/?INST\]"), _ => "",
+                new Regex(@"\[/?INST\]", RegexOptions.None, TimeSpan.FromMilliseconds(500)), _ => "",
                 MigrationCategory.Formatting, MigrationSeverity.Warning,
                 "Remove [INST]/[/INST] markers (not used by Google)"),
 
             // Meta → *: <<SYS>> markers
             new(LlmProvider.Meta, LlmProvider.OpenAI,
-                new Regex(@"<</?SYS>>"), _ => "",
+                new Regex(@"<</?SYS>>", RegexOptions.None, TimeSpan.FromMilliseconds(500)), _ => "",
                 MigrationCategory.SystemPrompt, MigrationSeverity.Warning,
                 "Remove <<SYS>> markers (use system message role instead)"),
             new(LlmProvider.Meta, LlmProvider.Anthropic,
-                new Regex(@"<</?SYS>>"), _ => "",
+                new Regex(@"<</?SYS>>", RegexOptions.None, TimeSpan.FromMilliseconds(500)), _ => "",
                 MigrationCategory.SystemPrompt, MigrationSeverity.Warning,
                 "Remove <<SYS>> markers (use system parameter instead)"),
             new(LlmProvider.Meta, LlmProvider.Google,
-                new Regex(@"<</?SYS>>"), _ => "",
+                new Regex(@"<</?SYS>>", RegexOptions.None, TimeSpan.FromMilliseconds(500)), _ => "",
                 MigrationCategory.SystemPrompt, MigrationSeverity.Warning,
                 "Remove <<SYS>> markers (use system_instruction instead)"),
 
             // Anthropic → OpenAI: Human/Assistant markers
             new(LlmProvider.Anthropic, LlmProvider.OpenAI,
-                new Regex(@"^Human:\s?", RegexOptions.Multiline), _ => "User: ",
+                new Regex(@"^Human:\s?", RegexOptions.Multiline, TimeSpan.FromMilliseconds(500)), _ => "User: ",
                 MigrationCategory.RoleConvention, MigrationSeverity.Info,
                 "Replace Human: with User: (OpenAI convention)"),
 
             // Any → Meta: need [INST] markers
             new(null, LlmProvider.Meta,
-                new Regex(@"^(?!\[INST\])(.+)", RegexOptions.None),
+                new Regex(@"^(?!\[INST\])(.+)", RegexOptions.None, TimeSpan.FromMilliseconds(500)),
                 _ => _.Value, // no auto-fix, just flag
                 MigrationCategory.Formatting, MigrationSeverity.Info,
                 "Consider wrapping instructions in [INST][/INST] markers for Llama"),
 
             // Anthropic → *: Anthropic-specific references
             new(LlmProvider.Anthropic, LlmProvider.OpenAI,
-                new Regex(@"\bAnthropic\b"), _ => "OpenAI",
+                new Regex(@"\bAnthropic\b", RegexOptions.None, TimeSpan.FromMilliseconds(500)), _ => "OpenAI",
                 MigrationCategory.RoleConvention, MigrationSeverity.Info,
                 "Replace Anthropic company references"),
             new(LlmProvider.Anthropic, LlmProvider.Google,
-                new Regex(@"\bAnthropic\b"), _ => "Google",
+                new Regex(@"\bAnthropic\b", RegexOptions.None, TimeSpan.FromMilliseconds(500)), _ => "Google",
                 MigrationCategory.RoleConvention, MigrationSeverity.Info,
                 "Replace Anthropic company references"),
 
             // OpenAI → *: OpenAI-specific references
             new(LlmProvider.OpenAI, LlmProvider.Anthropic,
-                new Regex(@"\bOpenAI\b"), _ => "Anthropic",
+                new Regex(@"\bOpenAI\b", RegexOptions.None, TimeSpan.FromMilliseconds(500)), _ => "Anthropic",
                 MigrationCategory.RoleConvention, MigrationSeverity.Info,
                 "Replace OpenAI company references"),
             new(LlmProvider.OpenAI, LlmProvider.Google,
-                new Regex(@"\bOpenAI\b"), _ => "Google",
+                new Regex(@"\bOpenAI\b", RegexOptions.None, TimeSpan.FromMilliseconds(500)), _ => "Google",
                 MigrationCategory.RoleConvention, MigrationSeverity.Info,
                 "Replace OpenAI company references"),
         };
@@ -677,7 +677,7 @@ namespace Prompt
             }
 
             // Clean up whitespace artifacts
-            migrated = Regex.Replace(migrated, @"\n{3,}", "\n\n");
+            migrated = Regex.Replace(migrated, @"\n{3,}", "\n\n", RegexOptions.None, TimeSpan.FromMilliseconds(500));
             migrated = migrated.Trim();
 
             // Recalculate issues after migration
@@ -792,7 +792,7 @@ namespace Prompt
             var issues = new List<MigrationIssue>();
 
             // XML tags: Anthropic loves them, others are neutral
-            var xmlTagCount = Regex.Matches(prompt, @"</?[a-zA-Z_][a-zA-Z0-9_-]*>").Count;
+            var xmlTagCount = Regex.Matches(prompt, @"</?[a-zA-Z_][a-zA-Z0-9_-]*>", RegexOptions.None, TimeSpan.FromMilliseconds(500)).Count;
             if (source == LlmProvider.Anthropic && xmlTagCount > 2 &&
                 target != LlmProvider.Anthropic)
             {
@@ -808,7 +808,7 @@ namespace Prompt
 
             // [INST] markers: Llama/Mistral
             if ((source == LlmProvider.Meta || source == LlmProvider.Mistral) &&
-                Regex.IsMatch(prompt, @"\[INST\]") &&
+                Regex.IsMatch(prompt, @"\[INST\]", RegexOptions.None, TimeSpan.FromMilliseconds(500)) &&
                 target != LlmProvider.Meta && target != LlmProvider.Mistral)
             {
                 issues.Add(new MigrationIssue
@@ -822,7 +822,7 @@ namespace Prompt
             }
 
             // <<SYS>> markers: Llama
-            if (source == LlmProvider.Meta && Regex.IsMatch(prompt, @"<<SYS>>") &&
+            if (source == LlmProvider.Meta && Regex.IsMatch(prompt, @"<<SYS>>", RegexOptions.None, TimeSpan.FromMilliseconds(500)) &&
                 target != LlmProvider.Meta)
             {
                 issues.Add(new MigrationIssue
@@ -836,7 +836,7 @@ namespace Prompt
             }
 
             // Human/Assistant markers: Anthropic convention
-            if (Regex.IsMatch(prompt, @"^Human:\s", RegexOptions.Multiline) &&
+            if (Regex.IsMatch(prompt, @"^Human:\s", RegexOptions.Multiline, TimeSpan.FromMilliseconds(500)) &&
                 target != LlmProvider.Anthropic)
             {
                 issues.Add(new MigrationIssue
@@ -850,7 +850,7 @@ namespace Prompt
             }
 
             // Markdown structure check
-            var hasMarkdownHeaders = Regex.IsMatch(prompt, @"^#{1,3}\s", RegexOptions.Multiline);
+            var hasMarkdownHeaders = Regex.IsMatch(prompt, @"^#{1,3}\s", RegexOptions.Multiline, TimeSpan.FromMilliseconds(500));
             if (!hasMarkdownHeaders && prompt.Length > 500 &&
                 target == LlmProvider.OpenAI)
             {
@@ -874,7 +874,7 @@ namespace Prompt
             var targetProfile = GetProfile(target);
 
             // JSON mode references
-            if (Regex.IsMatch(prompt, @"response_format.*json|json_object", RegexOptions.IgnoreCase) &&
+            if (Regex.IsMatch(prompt, @"response_format.*json|json_object", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)) &&
                 !targetProfile.SupportsJson)
             {
                 issues.Add(new MigrationIssue
@@ -888,7 +888,7 @@ namespace Prompt
             }
 
             // Tool/function calling references
-            if (Regex.IsMatch(prompt, @"\bfunction[_\s]?call|tool[_\s]?use|tool_choice", RegexOptions.IgnoreCase) &&
+            if (Regex.IsMatch(prompt, @"\bfunction[_\s]?call|tool[_\s]?use|tool_choice", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)) &&
                 !targetProfile.SupportsToolCalling)
             {
                 issues.Add(new MigrationIssue
@@ -902,7 +902,7 @@ namespace Prompt
             }
 
             // Image references
-            if (Regex.IsMatch(prompt, @"\bimage_url|vision|image\s+input", RegexOptions.IgnoreCase) &&
+            if (Regex.IsMatch(prompt, @"\bimage_url|vision|image\s+input", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)) &&
                 !targetProfile.SupportsImages)
             {
                 issues.Add(new MigrationIssue
@@ -917,7 +917,7 @@ namespace Prompt
 
             // Thinking blocks: Anthropic → others
             if (source == LlmProvider.Anthropic &&
-                Regex.IsMatch(prompt, @"<thinking>|think step by step in <thinking> tags", RegexOptions.IgnoreCase) &&
+                Regex.IsMatch(prompt, @"<thinking>|think step by step in <thinking> tags", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)) &&
                 target != LlmProvider.Anthropic)
             {
                 issues.Add(new MigrationIssue
@@ -932,7 +932,7 @@ namespace Prompt
 
             // System instruction reference: Google → others
             if (source == LlmProvider.Google &&
-                Regex.IsMatch(prompt, @"system_instruction", RegexOptions.IgnoreCase) &&
+                Regex.IsMatch(prompt, @"system_instruction", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)) &&
                 target != LlmProvider.Google)
             {
                 issues.Add(new MigrationIssue

--- a/src/PromptMinifier.cs
+++ b/src/PromptMinifier.cs
@@ -83,67 +83,67 @@ namespace Prompt
         // ── Pre-compiled cleanup patterns ──────────────────
 
         private static readonly Regex MultiSpaceCleanup = new(
-            @" {2,}", RegexOptions.Compiled);
+            @" {2,}", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         private static readonly Regex LeadingSpaceCleanup = new(
-            @"(?m)^ +", RegexOptions.Compiled);
+            @"(?m)^ +", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         // ──────────────── Filler Patterns (Light) ────────────────
 
         private static readonly (Regex Pattern, string Replacement, string Description)[] LightRules =
         {
             // Filler phrases
-            (new Regex(@"\b(please\s+)?(help\s+me\s+to|help\s+me)\s+", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\b(please\s+)?(help\s+me\s+to|help\s+me)\s+", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "", "Remove 'help me to'"),
 
             (new Regex(@"\b(I\s+would\s+like\s+(you\s+to|to)|I\s+want\s+you\s+to|I\s+need\s+you\s+to)\s+",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "", "Remove 'I would like you to'"),
 
             (new Regex(@"\b(could\s+you\s+(please\s+)?|can\s+you\s+(please\s+)?|would\s+you\s+(please\s+)?)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "", "Remove 'could you please'"),
 
-            (new Regex(@"\bplease\s+", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bplease\s+", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "", "Remove 'please'"),
 
             (new Regex(@"\b(basically|essentially|actually|obviously|clearly|simply|just|really|very|quite|rather)\s+",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "", "Remove hedge/filler words"),
 
             // Redundant phrases
-            (new Regex(@"\bin\s+order\s+to\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bin\s+order\s+to\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "to", "Simplify 'in order to' → 'to'"),
 
-            (new Regex(@"\bdue\s+to\s+the\s+fact\s+that\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bdue\s+to\s+the\s+fact\s+that\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "because", "Simplify 'due to the fact that' → 'because'"),
 
-            (new Regex(@"\bat\s+this\s+point\s+in\s+time\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bat\s+this\s+point\s+in\s+time\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "now", "Simplify 'at this point in time' → 'now'"),
 
-            (new Regex(@"\bin\s+the\s+event\s+that\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bin\s+the\s+event\s+that\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "if", "Simplify 'in the event that' → 'if'"),
 
-            (new Regex(@"\bfor\s+the\s+purpose\s+of\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bfor\s+the\s+purpose\s+of\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "for", "Simplify 'for the purpose of' → 'for'"),
 
-            (new Regex(@"\bwith\s+regard\s+to\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bwith\s+regard\s+to\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "about", "Simplify 'with regard to' → 'about'"),
 
-            (new Regex(@"\bin\s+terms\s+of\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bin\s+terms\s+of\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "regarding", "Simplify 'in terms of' → 'regarding'"),
 
-            (new Regex(@"\bhas\s+the\s+ability\s+to\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bhas\s+the\s+ability\s+to\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "can", "Simplify 'has the ability to' → 'can'"),
 
-            (new Regex(@"\bit\s+is\s+important\s+to\s+note\s+that\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bit\s+is\s+important\s+to\s+note\s+that\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "Note:", "Simplify 'it is important to note that' → 'Note:'"),
 
             // Whitespace normalization
-            (new Regex(@"[ \t]{2,}", RegexOptions.Compiled),
+            (new Regex(@"[ \t]{2,}", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 " ", "Normalize multiple spaces"),
 
-            (new Regex(@"\n{3,}", RegexOptions.Compiled),
+            (new Regex(@"\n{3,}", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "\n\n", "Normalize multiple blank lines"),
         };
 
@@ -153,37 +153,37 @@ namespace Prompt
         {
             // Politeness
             (new Regex(@"\b(thank\s+you|thanks)\s*(in\s+advance|for\s+your\s+help|so\s+much)?[.!]?\s*",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "", "Remove thank-you phrases"),
 
             (new Regex(@"\bI\s+appreciate\s+(your|any)\s+\w+[.!]?\s*",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "", "Remove appreciation phrases"),
 
             // Verbose instruction patterns
-            (new Regex(@"\bmake\s+sure\s+(to|that)\s+", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bmake\s+sure\s+(to|that)\s+", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "ensure ", "Condense 'make sure to' → 'ensure'"),
 
-            (new Regex(@"\btake\s+into\s+(account|consideration)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\btake\s+into\s+(account|consideration)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "consider", "Condense 'take into account' → 'consider'"),
 
-            (new Regex(@"\bprovide\s+(me\s+with|an?\s+)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bprovide\s+(me\s+with|an?\s+)", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "give ", "Condense 'provide me with' → 'give'"),
 
-            (new Regex(@"\bin\s+a\s+way\s+that\s+is\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bin\s+a\s+way\s+that\s+is\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "that is", "Condense 'in a way that is'"),
 
             (new Regex(@"\b(it\s+is|it's)\s+(important|necessary|essential|crucial|critical)\s+(to|that)\s+",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "Must ", "Condense 'it is important to' → 'Must'"),
 
-            (new Regex(@"\bas\s+much\s+as\s+possible\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bas\s+much\s+as\s+possible\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "maximally", "Condense 'as much as possible' → 'maximally'"),
 
-            (new Regex(@"\ba\s+large\s+number\s+of\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\ba\s+large\s+number\s+of\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "many", "Condense 'a large number of' → 'many'"),
 
-            (new Regex(@"\ba\s+small\s+number\s+of\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\ba\s+small\s+number\s+of\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "few", "Condense 'a small number of' → 'few'"),
         };
 
@@ -192,42 +192,42 @@ namespace Prompt
         private static readonly (Regex Pattern, string Replacement, string Description)[] AggressiveRules =
         {
             // Remove articles where meaning is preserved
-            (new Regex(@"\b(the|a|an)\s+(?=\w)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\b(the|a|an)\s+(?=\w)", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "", "Remove articles"),
 
             // Shorten common words
-            (new Regex(@"\binformation\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\binformation\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "info", "Shorten 'information' → 'info'"),
 
-            (new Regex(@"\bapplication\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bapplication\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "app", "Shorten 'application' → 'app'"),
 
-            (new Regex(@"\bconfiguration\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bconfiguration\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "config", "Shorten 'configuration' → 'config'"),
 
-            (new Regex(@"\bdocumentation\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bdocumentation\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "docs", "Shorten 'documentation' → 'docs'"),
 
-            (new Regex(@"\bimplementation\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bimplementation\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "impl", "Shorten 'implementation' → 'impl'"),
 
-            (new Regex(@"\benvironment\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\benvironment\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "env", "Shorten 'environment' → 'env'"),
 
-            (new Regex(@"\brepository\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\brepository\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "repo", "Shorten 'repository' → 'repo'"),
 
-            (new Regex(@"\bfunction(ality)?\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bfunction(ality)?\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "func", "Shorten 'functionality' → 'func'"),
 
-            (new Regex(@"\bfor\s+example\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bfor\s+example\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "e.g.", "Shorten 'for example' → 'e.g.'"),
 
-            (new Regex(@"\bthat\s+is\s+to\s+say\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\bthat\s+is\s+to\s+say\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "i.e.", "Shorten 'that is to say' → 'i.e.'"),
 
             // Remove filler prepositions in lists
-            (new Regex(@"\b(and|or)\s+also\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            (new Regex(@"\b(and|or)\s+also\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
                 "and", "Remove redundant 'also' after conjunctions"),
         };
 

--- a/src/PromptNegotiator.cs
+++ b/src/PromptNegotiator.cs
@@ -551,7 +551,7 @@ namespace Prompt
             {
                 ValidationRuleKind.JsonFormat => IsValidJson(response),
                 ValidationRuleKind.RegexMatch => !string.IsNullOrEmpty(rule.Parameter) &&
-                    System.Text.RegularExpressions.Regex.IsMatch(response, rule.Parameter),
+                    System.Text.RegularExpressions.Regex.IsMatch(response, rule.Parameter, RegexOptions.None, TimeSpan.FromMilliseconds(500)),
                 ValidationRuleKind.LengthRange => EvaluateLength(rule, response),
                 ValidationRuleKind.ContainsKeywords => EvaluateContains(rule, response),
                 ValidationRuleKind.ExcludesKeywords => EvaluateExcludes(rule, response),

--- a/src/PromptOutputValidator.cs
+++ b/src/PromptOutputValidator.cs
@@ -161,7 +161,7 @@ namespace Prompt
         /// <summary>Output must match the given regex pattern.</summary>
         public PromptOutputValidator MustMatchRegex(string pattern, string description = null)
         {
-            var regex = new Regex(pattern, RegexOptions.Compiled);
+            var regex = new Regex(pattern, RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
             _rules.Add(new OutputRule
             {
                 Name = "MustMatchRegex",
@@ -175,7 +175,7 @@ namespace Prompt
         /// <summary>Output must NOT match the given regex pattern.</summary>
         public PromptOutputValidator MustNotMatchRegex(string pattern, string description = null)
         {
-            var regex = new Regex(pattern, RegexOptions.Compiled);
+            var regex = new Regex(pattern, RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
             _rules.Add(new OutputRule
             {
                 Name = "MustNotMatchRegex",
@@ -329,7 +329,7 @@ namespace Prompt
         /// <summary>Output must contain a specific JSON key (simple top-level check).</summary>
         public PromptOutputValidator MustContainJsonKey(string key)
         {
-            var pattern = new Regex($"\"{ Regex.Escape(key) }\"\\s*:", RegexOptions.Compiled);
+            var pattern = new Regex($"\"{ Regex.Escape(key) }\"\\s*:", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
             _rules.Add(new OutputRule
             {
                 Name = $"MustContainJsonKey({key})",

--- a/src/PromptPipeline.cs
+++ b/src/PromptPipeline.cs
@@ -613,7 +613,7 @@ namespace Prompt
                 {
                     var key = match.Groups[1].Value;
                     return variables.TryGetValue(key, out var value) ? value : match.Value;
-                });
+                }, RegexOptions.None, TimeSpan.FromMilliseconds(500));
             }
 
             // Recursive mode: iterate until no more substitutions or depth exhausted
@@ -625,7 +625,7 @@ namespace Prompt
                 {
                     var key = match.Groups[1].Value;
                     return variables.TryGetValue(key, out var value) ? value : match.Value;
-                });
+                }, RegexOptions.None, TimeSpan.FromMilliseconds(500));
 
                 // No changes in this pass → stable, stop early
                 if (string.Equals(result, previous, StringComparison.Ordinal))

--- a/src/PromptRefactorer.cs
+++ b/src/PromptRefactorer.cs
@@ -501,7 +501,7 @@ namespace Prompt
         {
             var suggestions = new List<RefactorSuggestion>();
             var lower = prompt.ToLowerInvariant();
-            var words = Regex.Split(lower, @"\W+").Where(w => w.Length > 3).ToArray();
+            var words = Regex.Split(lower, @"\W+", RegexOptions.None, TimeSpan.FromMilliseconds(500)).Where(w => w.Length > 3).ToArray();
 
             // Word frequency — flag words repeated too many times
             var freq = new Dictionary<string, int>();
@@ -638,7 +638,7 @@ namespace Prompt
 
             // Detect repeated literal values that could be variables
             // Look for quoted strings or specific patterns repeated
-            var quotedPattern = new Regex(@"""([^""]{3,50})""", RegexOptions.Compiled);
+            var quotedPattern = new Regex(@"""([^""]{3,50})""", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
             var matches = quotedPattern.Matches(prompt);
             var quotedValues = new Dictionary<string, List<int>>();
 
@@ -669,7 +669,7 @@ namespace Prompt
             }
 
             // Detect hardcoded numbers that might be configurable
-            var numberPattern = new Regex(@"\b(\d{2,})\b");
+            var numberPattern = new Regex(@"\b(\d{2,})\b", RegexOptions.None, TimeSpan.FromMilliseconds(500));
             var numbers = new Dictionary<string, List<int>>();
             foreach (Match m in numberPattern.Matches(prompt))
             {
@@ -894,7 +894,7 @@ namespace Prompt
             // Detect markdown headers, numbered sections, or labeled sections
             var headerPattern = new Regex(
                 @"^(#{1,3}\s+.+|[A-Z][A-Za-z\s]{2,30}:\s*$|\d+\.\s+[A-Z].+)",
-                RegexOptions.Multiline);
+                RegexOptions.Multiline, TimeSpan.FromMilliseconds(500));
 
             var matches = headerPattern.Matches(prompt);
             for (int i = 0; i < matches.Count; i++)
@@ -925,7 +925,7 @@ namespace Prompt
 
         private static List<string> DetectVariables(string prompt)
         {
-            var pattern = new Regex(@"\{\{(\w+)\}\}");
+            var pattern = new Regex(@"\{\{(\w+)\}\}", RegexOptions.None, TimeSpan.FromMilliseconds(500));
             return pattern.Matches(prompt)
                 .Select(m => m.Groups[1].Value)
                 .Distinct()
@@ -935,7 +935,7 @@ namespace Prompt
         private static string SuggestVariableName(string value)
         {
             // Generate a sensible variable name from a literal value
-            var cleaned = Regex.Replace(value.ToLowerInvariant(), @"[^a-z0-9\s]", "");
+            var cleaned = Regex.Replace(value.ToLowerInvariant(), @"[^a-z0-9\s]", "", RegexOptions.None, TimeSpan.FromMilliseconds(500));
             var words = cleaned.Split(' ', StringSplitOptions.RemoveEmptyEntries);
             if (words.Length == 0) return "value";
             if (words.Length == 1) return words[0];

--- a/src/PromptResponseEvaluator.cs
+++ b/src/PromptResponseEvaluator.cs
@@ -337,7 +337,7 @@ namespace Prompt
         /// </summary>
         private DimensionScore EvaluateConciseness(string prompt, string response)
         {
-            var words = Regex.Split(response, @"\s+")
+            var words = Regex.Split(response, @"\s+", RegexOptions.None, TimeSpan.FromMilliseconds(500))
                 .Where(w => w.Length > 0).ToArray();
 
             if (words.Length == 0)
@@ -361,12 +361,12 @@ namespace Prompt
             double uniqueRatio = (double)uniqueWords.Count / words.Length;
 
             // 3. Length proportionality — very long responses to short prompts are penalized
-            var promptWords = Regex.Split(prompt, @"\s+").Where(w => w.Length > 0).Count();
+            var promptWords = Regex.Split(prompt, @"\s+", RegexOptions.None, TimeSpan.FromMilliseconds(500)).Where(w => w.Length > 0).Count();
             double lengthRatio = (double)words.Length / Math.Max(1, promptWords);
             double lengthPenalty = lengthRatio > 20 ? 0.15 : lengthRatio > 10 ? 0.05 : 0;
 
             // 4. Sentence-level repetition
-            var sentences = Regex.Split(response, @"[.!?]+")
+            var sentences = Regex.Split(response, @"[.!?]+", RegexOptions.None, TimeSpan.FromMilliseconds(500))
                 .Select(s => s.Trim().ToLowerInvariant())
                 .Where(s => s.Length > 10)
                 .ToList();
@@ -402,18 +402,18 @@ namespace Prompt
             double penalty = 0;
 
             // 1. Check for PII patterns
-            if (Regex.IsMatch(response, @"\b\d{3}-\d{2}-\d{4}\b"))
+            if (Regex.IsMatch(response, @"\b\d{3}-\d{2}-\d{4}\b", RegexOptions.None, TimeSpan.FromMilliseconds(500)))
             {
                 issues.Add("Possible SSN detected");
                 penalty += 0.3;
             }
-            if (Regex.IsMatch(response, @"\b\d{16}\b|\b\d{4}[- ]\d{4}[- ]\d{4}[- ]\d{4}\b"))
+            if (Regex.IsMatch(response, @"\b\d{16}\b|\b\d{4}[- ]\d{4}[- ]\d{4}[- ]\d{4}\b", RegexOptions.None, TimeSpan.FromMilliseconds(500)))
             {
                 issues.Add("Possible credit card number");
                 penalty += 0.3;
             }
             if (Regex.IsMatch(response, @"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b",
-                RegexOptions.IgnoreCase))
+                RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)))
             {
                 issues.Add("Email address detected");
                 penalty += 0.1;
@@ -429,7 +429,7 @@ namespace Prompt
             };
             foreach (var pattern in leakagePatterns)
             {
-                if (Regex.IsMatch(response, pattern))
+                if (Regex.IsMatch(response, pattern, RegexOptions.None, TimeSpan.FromMilliseconds(500)))
                 {
                     issues.Add("Possible system prompt leakage");
                     penalty += 0.15;
@@ -445,7 +445,7 @@ namespace Prompt
             };
             foreach (var pattern in refusalPatterns)
             {
-                if (Regex.IsMatch(response.Trim(), pattern))
+                if (Regex.IsMatch(response.Trim(), pattern, RegexOptions.None, TimeSpan.FromMilliseconds(500)))
                 {
                     issues.Add("Canned refusal detected");
                     penalty += 0.2;
@@ -487,7 +487,7 @@ namespace Prompt
                 "please", "make", "create", "show", "include"
             };
 
-            var words = Regex.Split(text.ToLowerInvariant(), @"[^\w]+")
+            var words = Regex.Split(text.ToLowerInvariant(), @"[^\w]+", RegexOptions.None, TimeSpan.FromMilliseconds(500))
                 .Where(w => w.Length > 2 && !stopWords.Contains(w))
                 .ToHashSet();
 
@@ -499,7 +499,7 @@ namespace Prompt
         /// </summary>
         internal static List<string> ExtractEntities(string text)
         {
-            var matches = Regex.Matches(text, @"(?<=[.!?]\s+|\n)([A-Z][a-z]+)|(?<=\s)([A-Z][a-z]{2,})");
+            var matches = Regex.Matches(text, @"(?<=[.!?]\s+|\n)([A-Z][a-z]+)|(?<=\s)([A-Z][a-z]{2,})", RegexOptions.None, TimeSpan.FromMilliseconds(500));
             return matches.Select(m => m.Value)
                 .Where(v => v.Length > 2)
                 .Distinct()
@@ -516,24 +516,24 @@ namespace Prompt
             var parts = new List<string>();
 
             // Try numbered items: "1. ... 2. ... 3. ..."
-            var numbered = Regex.Split(prompt, @"(?<=\n|^)\s*\d+[.)]\s*")
+            var numbered = Regex.Split(prompt, @"(?<=\n|^)\s*\d+[.)]\s*", RegexOptions.None, TimeSpan.FromMilliseconds(500))
                 .Where(s => s.Trim().Length > 5).ToList();
             if (numbered.Count > 1) return numbered;
 
             // Try bullet points
-            var bullets = Regex.Split(prompt, @"(?<=\n|^)\s*[-*\u2022]\s+")
+            var bullets = Regex.Split(prompt, @"(?<=\n|^)\s*[-*\u2022]\s+", RegexOptions.None, TimeSpan.FromMilliseconds(500))
                 .Where(s => s.Trim().Length > 5).ToList();
             if (bullets.Count > 1) return bullets;
 
             // Try "and"/"also" conjunctions for multi-instruction prompts
             var conjunctions = Regex.Split(prompt,
                 @"\b(?:and also|and then|also|additionally|furthermore|moreover)\b",
-                RegexOptions.IgnoreCase)
+                RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500))
                 .Where(s => s.Trim().Length > 10).ToList();
             if (conjunctions.Count > 1) return conjunctions;
 
             // Try multiple questions
-            var questions = Regex.Split(prompt, @"\?\s+")
+            var questions = Regex.Split(prompt, @"\?\s+", RegexOptions.None, TimeSpan.FromMilliseconds(500))
                 .Where(s => s.Trim().Length > 5).ToList();
             if (questions.Count > 1) return questions;
 
@@ -548,15 +548,15 @@ namespace Prompt
         {
             var lower = prompt.ToLowerInvariant();
 
-            if (Regex.IsMatch(lower, @"\bjson\b|json format|json object|json array"))
+            if (Regex.IsMatch(lower, @"\bjson\b|json format|json object|json array", RegexOptions.None, TimeSpan.FromMilliseconds(500)))
                 return ResponseFormat.Json;
-            if (Regex.IsMatch(lower, @"\blist\b.*\d|numbered list|bullet(ed)? (list|points?)"))
+            if (Regex.IsMatch(lower, @"\blist\b.*\d|numbered list|bullet(ed)? (list|points?)", RegexOptions.None, TimeSpan.FromMilliseconds(500)))
                 return ResponseFormat.List;
-            if (Regex.IsMatch(lower, @"\bcode\b|function|class|implement|program|script"))
+            if (Regex.IsMatch(lower, @"\bcode\b|function|class|implement|program|script", RegexOptions.None, TimeSpan.FromMilliseconds(500)))
                 return ResponseFormat.Code;
-            if (Regex.IsMatch(lower, @"\btable\b|tabular|columns?|rows?.*header"))
+            if (Regex.IsMatch(lower, @"\btable\b|tabular|columns?|rows?.*header", RegexOptions.None, TimeSpan.FromMilliseconds(500)))
                 return ResponseFormat.Table;
-            if (Regex.IsMatch(lower, @"step.by.step|steps?\b|instructions?|how to"))
+            if (Regex.IsMatch(lower, @"step.by.step|steps?\b|instructions?|how to", RegexOptions.None, TimeSpan.FromMilliseconds(500)))
                 return ResponseFormat.StepByStep;
 
             return ResponseFormat.None;
@@ -565,7 +565,7 @@ namespace Prompt
         private static bool ContainsJson(string text)
         {
             // Look for { ... } or [ ... ] blocks
-            var match = Regex.Match(text, @"[\[{][\s\S]*?[\]}]");
+            var match = Regex.Match(text, @"[\[{][\s\S]*?[\]}]", RegexOptions.None, TimeSpan.FromMilliseconds(500));
             if (!match.Success) return false;
             try
             {
@@ -577,25 +577,25 @@ namespace Prompt
 
         private static bool ContainsList(string text)
         {
-            return Regex.IsMatch(text, @"(?m)^\s*(\d+[.)]\s+|-\s+|\*\s+|\u2022\s+)");
+            return Regex.IsMatch(text, @"(?m)^\s*(\d+[.)]\s+|-\s+|\*\s+|\u2022\s+)", RegexOptions.None, TimeSpan.FromMilliseconds(500));
         }
 
         private static bool ContainsCodeBlock(string text)
         {
             return text.Contains("```") ||
-                   Regex.IsMatch(text, @"(?m)^    \S.*\n(    \S.*\n){2,}");
+                   Regex.IsMatch(text, @"(?m)^    \S.*\n(    \S.*\n){2,}", RegexOptions.None, TimeSpan.FromMilliseconds(500));
         }
 
         private static bool ContainsTable(string text)
         {
-            return Regex.IsMatch(text, @"\|.*\|.*\|") &&
-                   Regex.IsMatch(text, @"\|[\s-:]+\|");
+            return Regex.IsMatch(text, @"\|.*\|.*\|", RegexOptions.None, TimeSpan.FromMilliseconds(500)) &&
+                   Regex.IsMatch(text, @"\|[\s-:]+\|", RegexOptions.None, TimeSpan.FromMilliseconds(500));
         }
 
         private static bool ContainsSteps(string text)
         {
             var stepMatches = Regex.Matches(text,
-                @"(?mi)^(?:step\s+\d+|(?:\d+)[.)]\s)");
+                @"(?mi)^(?:step\s+\d+|(?:\d+)[.)]\s)", RegexOptions.None, TimeSpan.FromMilliseconds(500));
             return stepMatches.Count >= 2;
         }
 

--- a/src/PromptRouter.cs
+++ b/src/PromptRouter.cs
@@ -155,7 +155,7 @@ namespace Prompt
         {
             var results = new List<RouteMatch>();
             var lowerInput = (input ?? "").ToLowerInvariant();
-            var words = Regex.Split(lowerInput, @"\W+").Where(w => w.Length > 0).ToHashSet();
+            var words = Regex.Split(lowerInput, @"\W+", RegexOptions.None, TimeSpan.FromMilliseconds(500)).Where(w => w.Length > 0).ToHashSet();
 
             foreach (var (name, config) in _routes)
             {

--- a/src/PromptSanitizer.cs
+++ b/src/PromptSanitizer.cs
@@ -94,22 +94,22 @@ namespace Prompt
     /// </example>
     public class PromptSanitizer
     {
-        private static readonly Regex MultipleSpaces = new(@"[ \t]{2,}", RegexOptions.Compiled);
-        private static readonly Regex MultipleBlankLines = new(@"(\r?\n){3,}", RegexOptions.Compiled);
-        private static readonly Regex TrailingLineSpaces = new(@"[ \t]+(?=\r?\n|$)", RegexOptions.Compiled);
-        private static readonly Regex LeadingLineSpaces = new(@"(?<=\r?\n)[ \t]+", RegexOptions.Compiled);
+        private static readonly Regex MultipleSpaces = new(@"[ \t]{2,}", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
+        private static readonly Regex MultipleBlankLines = new(@"(\r?\n){3,}", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
+        private static readonly Regex TrailingLineSpaces = new(@"[ \t]+(?=\r?\n|$)", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
+        private static readonly Regex LeadingLineSpaces = new(@"(?<=\r?\n)[ \t]+", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         // PII patterns
         private static readonly Regex EmailPattern = new(
-            @"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b", RegexOptions.Compiled);
+            @"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
         private static readonly Regex PhonePattern = new(
-            @"(?<!\d)(\+?1[-.\s]?)?(\(?\d{3}\)?[-.\s]?)?\d{3}[-.\s]?\d{4}(?!\d)", RegexOptions.Compiled);
+            @"(?<!\d)(\+?1[-.\s]?)?(\(?\d{3}\)?[-.\s]?)?\d{3}[-.\s]?\d{4}(?!\d)", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
         private static readonly Regex SsnPattern = new(
-            @"\b\d{3}-\d{2}-\d{4}\b", RegexOptions.Compiled);
+            @"\b\d{3}-\d{2}-\d{4}\b", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
         private static readonly Regex CreditCardPattern = new(
-            @"\b(?:\d[ -]*?){13,16}\b", RegexOptions.Compiled);
+            @"\b(?:\d[ -]*?){13,16}\b", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
         private static readonly Regex IpAddressPattern = new(
-            @"\b(?:\d{1,3}\.){3}\d{1,3}\b", RegexOptions.Compiled);
+            @"\b(?:\d{1,3}\.){3}\d{1,3}\b", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         // Injection patterns — phrases commonly used to override system prompts
         private static readonly string[] InjectionPhrases = new[]
@@ -153,7 +153,7 @@ namespace Prompt
         // Zero-width and invisible Unicode characters
         private static readonly Regex InvisibleChars = new(
             @"[\u200B\u200C\u200D\u200E\u200F\u202A-\u202E\u2060\u2061\u2062\u2063\u2064\uFEFF\u00AD\u034F\u061C\u180E]",
-            RegexOptions.Compiled);
+            RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         /// <summary>
         /// Sanitize a prompt using default options.

--- a/src/PromptSemanticSearch.cs
+++ b/src/PromptSemanticSearch.cs
@@ -498,7 +498,7 @@ namespace Prompt
                 return new List<string>();
 
             // Split on non-alphanumeric, lowercase, filter stop words, stem
-            var tokens = Regex.Split(text.ToLowerInvariant(), @"[^a-z0-9]+")
+            var tokens = Regex.Split(text.ToLowerInvariant(), @"[^a-z0-9]+", RegexOptions.None, TimeSpan.FromMilliseconds(500))
                 .Where(t => t.Length >= 2 && !StopWords.Contains(t))
                 .Select(Stem)
                 .Where(t => t.Length >= 2)

--- a/src/PromptSignature.cs
+++ b/src/PromptSignature.cs
@@ -766,7 +766,7 @@ namespace Prompt
         private static string ExtractJsonBlock(string response)
         {
             // Try to extract JSON from markdown code block
-            var match = Regex.Match(response, @"```(?:json)?\s*\n?([\s\S]*?)\n?```", RegexOptions.Multiline);
+            var match = Regex.Match(response, @"```(?:json)?\s*\n?([\s\S]*?)\n?```", RegexOptions.Multiline, TimeSpan.FromMilliseconds(500));
             if (match.Success)
                 return match.Groups[1].Value.Trim();
 

--- a/src/PromptStreamParser.cs
+++ b/src/PromptStreamParser.cs
@@ -428,7 +428,7 @@ namespace Prompt
                     var lineEnd = text.IndexOf('\n', i);
                     if (lineEnd == -1) { _processedUpTo = i; return; }
                     var line = text.Substring(i, lineEnd - i).TrimEnd();
-                    var match = Regex.Match(line, @"^(#{1,6})\s+(.+)$");
+                    var match = Regex.Match(line, @"^(#{1,6})\s+(.+)$", RegexOptions.None, TimeSpan.FromMilliseconds(500));
                     if (match.Success)
                     {
                         EmitContent(new StreamContent
@@ -507,7 +507,7 @@ namespace Prompt
                     var lineEnd = text.IndexOf('\n', i);
                     if (lineEnd == -1) { _processedUpTo = i; return; }
                     var line = text.Substring(i, lineEnd - i);
-                    var kvMatch = Regex.Match(line, @"^\s{0,3}\*{0,2}([A-Za-z][\w\s]{0,40}?)\*{0,2}\s*:\s+(.+)$");
+                    var kvMatch = Regex.Match(line, @"^\s{0,3}\*{0,2}([A-Za-z][\w\s]{0,40}?)\*{0,2}\s*:\s+(.+)$", RegexOptions.None, TimeSpan.FromMilliseconds(500));
                     if (kvMatch.Success && !line.TrimStart().StartsWith("http", StringComparison.OrdinalIgnoreCase))
                     {
                         EmitContent(new StreamContent
@@ -534,7 +534,7 @@ namespace Prompt
             var trimmed = line.TrimStart();
             if (trimmed.StartsWith("- ") || trimmed.StartsWith("* ") || trimmed.StartsWith("+ "))
                 return true;
-            return Regex.IsMatch(trimmed, @"^\d+\.\s");
+            return Regex.IsMatch(trimmed, @"^\d+\.\s", RegexOptions.None, TimeSpan.FromMilliseconds(500));
         }
 
         private static bool IsLikelyJsonArray(string text, int pos)

--- a/src/PromptTemplate.cs
+++ b/src/PromptTemplate.cs
@@ -40,7 +40,7 @@ namespace Prompt
         internal const int MaxJsonPayloadBytes = SerializationGuards.MaxJsonPayloadBytes;
 
         private static readonly Regex VariablePattern =
-            new Regex(@"\{\{(\w+)\}\}", RegexOptions.Compiled);
+            new Regex(@"\{\{(\w+)\}\}", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         private readonly string _template;
         private readonly Dictionary<string, string> _defaults;

--- a/src/PromptTokenOptimizer.cs
+++ b/src/PromptTokenOptimizer.cs
@@ -221,29 +221,29 @@ namespace Prompt
         // Common filler patterns with their condensed forms
         private static readonly (Regex Pattern, string Replacement, string Description)[] FillerPatterns = new[]
         {
-            (new Regex(@"\bplease\s+make\s+sure\s+to\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), "ensure", "Verbose instruction phrase"),
-            (new Regex(@"\bI\s+would\s+like\s+you\s+to\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), "", "Unnecessary preamble"),
-            (new Regex(@"\bIt\s+is\s+important\s+(?:that\s+)?(?:you\s+)?\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), "", "Unnecessary emphasis"),
-            (new Regex(@"\bplease\s+note\s+that\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), "Note:", "Verbose note marker"),
-            (new Regex(@"\bIn\s+order\s+to\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), "To", "Verbose 'in order to'"),
-            (new Regex(@"\bDue\s+to\s+the\s+fact\s+that\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), "Because", "Verbose 'due to the fact that'"),
-            (new Regex(@"\bAt\s+this\s+point\s+in\s+time\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), "Now", "Verbose time reference"),
-            (new Regex(@"\bfor\s+the\s+purpose\s+of\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), "for", "Verbose 'for the purpose of'"),
-            (new Regex(@"\bin\s+the\s+event\s+that\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), "if", "Verbose conditional"),
-            (new Regex(@"\bwith\s+regard\s+to\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), "regarding", "Verbose 'with regard to'"),
-            (new Regex(@"\bAs\s+a\s+matter\s+of\s+fact\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), "In fact", "Verbose filler"),
-            (new Regex(@"\bIt\s+should\s+be\s+noted\s+that\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), "Note:", "Passive filler"),
-            (new Regex(@"\bYou\s+should\s+always\s+make\s+sure\s+(?:that\s+)?\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), "Always ", "Verbose instruction"),
-            (new Regex(@"\bI\s+need\s+you\s+to\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), "", "Unnecessary preamble"),
+            (new Regex(@"\bplease\s+make\s+sure\s+to\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)), "ensure", "Verbose instruction phrase"),
+            (new Regex(@"\bI\s+would\s+like\s+you\s+to\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)), "", "Unnecessary preamble"),
+            (new Regex(@"\bIt\s+is\s+important\s+(?:that\s+)?(?:you\s+)?\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)), "", "Unnecessary emphasis"),
+            (new Regex(@"\bplease\s+note\s+that\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)), "Note:", "Verbose note marker"),
+            (new Regex(@"\bIn\s+order\s+to\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)), "To", "Verbose 'in order to'"),
+            (new Regex(@"\bDue\s+to\s+the\s+fact\s+that\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)), "Because", "Verbose 'due to the fact that'"),
+            (new Regex(@"\bAt\s+this\s+point\s+in\s+time\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)), "Now", "Verbose time reference"),
+            (new Regex(@"\bfor\s+the\s+purpose\s+of\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)), "for", "Verbose 'for the purpose of'"),
+            (new Regex(@"\bin\s+the\s+event\s+that\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)), "if", "Verbose conditional"),
+            (new Regex(@"\bwith\s+regard\s+to\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)), "regarding", "Verbose 'with regard to'"),
+            (new Regex(@"\bAs\s+a\s+matter\s+of\s+fact\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)), "In fact", "Verbose filler"),
+            (new Regex(@"\bIt\s+should\s+be\s+noted\s+that\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)), "Note:", "Passive filler"),
+            (new Regex(@"\bYou\s+should\s+always\s+make\s+sure\s+(?:that\s+)?\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)), "Always ", "Verbose instruction"),
+            (new Regex(@"\bI\s+need\s+you\s+to\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)), "", "Unnecessary preamble"),
         };
 
         // Repeated formatting instruction patterns
         private static readonly Regex[] FormattingPatterns = new[]
         {
-            new Regex(@"\bformat\s+(?:the\s+)?(?:output|response|answer)\s+(?:as|in|using)\s+(?:JSON|json)\b", RegexOptions.Compiled),
-            new Regex(@"\breturn\s+(?:the\s+)?(?:result|output|response)\s+(?:as|in)\s+(?:JSON|json)\b", RegexOptions.Compiled),
-            new Regex(@"\buse\s+(?:bullet\s+)?(?:points|list|markdown)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
-            new Regex(@"\brespond\s+in\s+(?:JSON|json|XML|xml|markdown)\b", RegexOptions.Compiled),
+            new Regex(@"\bformat\s+(?:the\s+)?(?:output|response|answer)\s+(?:as|in|using)\s+(?:JSON|json)\b", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
+            new Regex(@"\breturn\s+(?:the\s+)?(?:result|output|response)\s+(?:as|in)\s+(?:JSON|json)\b", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
+            new Regex(@"\buse\s+(?:bullet\s+)?(?:points|list|markdown)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
+            new Regex(@"\brespond\s+in\s+(?:JSON|json|XML|xml|markdown)\b", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500)),
         };
 
         /// <summary>
@@ -409,7 +409,7 @@ namespace Prompt
                         currentChunk.Clear();
                         currentTokens = 0;
                     }
-                    var sentences = Regex.Split(section.Content, @"(?<=[.!?])\s+");
+                    var sentences = Regex.Split(section.Content, @"(?<=[.!?])\s+", RegexOptions.None, TimeSpan.FromMilliseconds(500));
                     var sentenceChunk = new List<string>();
                     var sentenceTokens = 0;
                     foreach (var s in sentences)
@@ -458,7 +458,7 @@ namespace Prompt
 
             try
             {
-                var parts = Regex.Split(prompt, _config.SectionPattern, RegexOptions.Multiline);
+                var parts = Regex.Split(prompt, _config.SectionPattern, RegexOptions.Multiline, TimeSpan.FromMilliseconds(500));
                 var index = 0;
 
                 foreach (var part in parts)
@@ -505,7 +505,7 @@ namespace Prompt
 
         private static string ExtractSectionName(string text)
         {
-            var headingMatch = Regex.Match(text, @"^#{1,3}\s+(.+?)(?:\n|$)");
+            var headingMatch = Regex.Match(text, @"^#{1,3}\s+(.+?)(?:\n|$)", RegexOptions.None, TimeSpan.FromMilliseconds(500));
             if (headingMatch.Success)
                 return headingMatch.Groups[1].Value.Trim();
 
@@ -535,7 +535,7 @@ namespace Prompt
                 }
 
                 // Detect instruction-like lines
-                if (Regex.IsMatch(trimmed, @"^(?:[-*•]\s|[\d]+[.)]\s|You\s+(?:should|must|need|will)|Always\s|Never\s|Do\s+not|Don't|Ensure|Make\s+sure|Remember)", RegexOptions.IgnoreCase))
+                if (Regex.IsMatch(trimmed, @"^(?:[-*•]\s|[\d]+[.)]\s|You\s+(?:should|must|need|will)|Always\s|Never\s|Do\s+not|Don't|Ensure|Make\s+sure|Remember)", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)))
                 {
                     if (current.Length > 0)
                     {
@@ -609,7 +609,7 @@ namespace Prompt
 
         private static List<string> Tokenize(string text)
         {
-            return Regex.Matches(text.ToLowerInvariant(), @"\b\w+\b")
+            return Regex.Matches(text.ToLowerInvariant(), @"\b\w+\b", RegexOptions.None, TimeSpan.FromMilliseconds(500))
                 .Select(m => m.Value)
                 .Where(w => w.Length > 1) // skip single chars
                 .ToList();
@@ -653,7 +653,7 @@ namespace Prompt
                 if (section.TokenCount < _config.VerbosityThreshold) continue;
 
                 // Check for high word-to-instruction ratio
-                var sentences = Regex.Split(section.Content, @"(?<=[.!?])\s+");
+                var sentences = Regex.Split(section.Content, @"(?<=[.!?])\s+", RegexOptions.None, TimeSpan.FromMilliseconds(500));
                 var longSentences = sentences.Where(s => EstimateTokens(s) > 30).ToList();
 
                 if (longSentences.Count > 0)
@@ -710,7 +710,7 @@ namespace Prompt
             // Detect long example blocks
             var exampleMatches = Regex.Matches(prompt,
                 @"(?:Example|e\.g\.|for\s+example|for\s+instance)[:\s](.+?)(?=\n\n|\z)",
-                RegexOptions.IgnoreCase | RegexOptions.Singleline);
+                RegexOptions.IgnoreCase | RegexOptions.Singleline, TimeSpan.FromMilliseconds(500));
 
             var totalExampleTokens = 0;
             foreach (Match m in exampleMatches)
@@ -739,7 +739,7 @@ namespace Prompt
             // Detect very specific constraint lists
             var constraintPattern = new Regex(
                 @"(?:must|should|always|never|do not|don't|ensure|make sure)(?:\s+\w+){5,}",
-                RegexOptions.IgnoreCase);
+                RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500));
 
             var constraints = constraintPattern.Matches(prompt);
             if (constraints.Count > 5)
@@ -771,8 +771,8 @@ namespace Prompt
             }
 
             // Normalize whitespace
-            result = Regex.Replace(result, @"\n{3,}", "\n\n");
-            result = Regex.Replace(result, @"[ \t]{2,}", " ");
+            result = Regex.Replace(result, @"\n{3,}", "\n\n", RegexOptions.None, TimeSpan.FromMilliseconds(500));
+            result = Regex.Replace(result, @"[ \t]{2,}", " ", RegexOptions.None, TimeSpan.FromMilliseconds(500));
 
             return result.Trim();
         }

--- a/src/PromptToolFormatter.cs
+++ b/src/PromptToolFormatter.cs
@@ -102,7 +102,7 @@ namespace Prompt
                 var errors = new List<string>();
                 if (string.IsNullOrWhiteSpace(Name))
                     errors.Add("Tool name is required");
-                else if (!Regex.IsMatch(Name, @"^[a-zA-Z_][a-zA-Z0-9_-]*$"))
+                else if (!Regex.IsMatch(Name, @"^[a-zA-Z_][a-zA-Z0-9_-]*$", RegexOptions.None, TimeSpan.FromMilliseconds(500)))
                     errors.Add($"Tool name '{Name}' contains invalid characters (use letters, digits, underscores, hyphens)");
                 if (Name.Length > 64)
                     errors.Add($"Tool name '{Name}' exceeds 64 character limit");

--- a/src/PromptVariantGenerator.cs
+++ b/src/PromptVariantGenerator.cs
@@ -406,7 +406,7 @@ namespace Prompt
         };
 
         private static readonly Regex[] CompiledFillerPatterns =
-            FillerPatterns.Select(p => new Regex(p, RegexOptions.IgnoreCase | RegexOptions.Compiled)).ToArray();
+            FillerPatterns.Select(p => new Regex(p, RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500))).ToArray();
 
         // ── Elaboration suffixes for detailed mode ───────────
 
@@ -423,17 +423,17 @@ namespace Prompt
 
         private static readonly Regex QuestionPattern = new(
             @"^(Can|Could|Would|Will)\s+you\s+(.+?)(\?)?$",
-            RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+            RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         private static readonly Regex DescriptiveTaskPattern = new(
             @"^(Your\s+task\s+is\s+to|The\s+(?:task|goal)\s+is\s+to)\s+(.+)$",
-            RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+            RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         private static readonly Regex MultiSpacePattern = new(
-            @"  +", RegexOptions.Compiled);
+            @"  +", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         private static readonly Regex ExcessiveNewlinePattern = new(
-            @"\n{3,}", RegexOptions.Compiled);
+            @"\n{3,}", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         /// <summary>
         /// Creates a new variant generator.
@@ -716,7 +716,7 @@ namespace Prompt
             foreach (var kvp in replacements)
             {
                 string pattern = @"(?<=\b|^)" + Regex.Escape(kvp.Key) + @"(?=\b|$)";
-                text = Regex.Replace(text, pattern, kvp.Value, RegexOptions.IgnoreCase);
+                text = Regex.Replace(text, pattern, kvp.Value, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500));
             }
             return text;
         }

--- a/src/ResponseParser.cs
+++ b/src/ResponseParser.cs
@@ -51,7 +51,7 @@ namespace Prompt
             @"^\s*(?:yes|true|correct|affirmative|absolutely|certainly|indeed|definitely)\b" +
             @"|\bthat(?:'s| is) (?:correct|right|true)\b" +
             @"|\byes,?\s+(?:it|that|this)\b",
-            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500));
 
         private static readonly Regex NoPattern = new(
             @"^\s*(?:no|false|incorrect|negative)\b" +
@@ -59,35 +59,35 @@ namespace Prompt
             @"|\bdon'?t think so\b" +
             @"|\bthat(?:'s| is) (?:incorrect|wrong|false)\b" +
             @"|\bno,?\s+(?:it|that|this)\b",
-            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500));
 
         // Pre-compiled regex for ExtractNumbers
         private static readonly Regex NumberPattern =
-            new Regex(@"(?<!\w)-?(?:\d{1,3}(?:,\d{3})*|\d+)(?:\.\d+)?(?!\w)", RegexOptions.Compiled);
+            new Regex(@"(?<!\w)-?(?:\d{1,3}(?:,\d{3})*|\d+)(?:\.\d+)?(?!\w)", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         // Pre-compiled regex for ExtractList
         private static readonly Regex ListItemPattern =
-            new Regex(@"^\s*(?:\d+[\.\)]\s+|[-\*•]\s+)(.+)$", RegexOptions.Compiled);
+            new Regex(@"^\s*(?:\d+[\.\)]\s+|[-\*•]\s+)(.+)$", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         // Pre-compiled regex for ExtractNumberedList
         private static readonly Regex NumberedListPattern =
-            new Regex(@"^\s*(\d+)[\.\)]\s+(.+)$", RegexOptions.Compiled | RegexOptions.Multiline);
+            new Regex(@"^\s*(\d+)[\.\)]\s+(.+)$", RegexOptions.Compiled | RegexOptions.Multiline, TimeSpan.FromMilliseconds(500));
 
         // Pre-compiled regex for ExtractKeyValuePairs
         private static readonly Regex KeyValuePattern =
-            new Regex(@"^\s*\*{0,2}([^:=\-\n]+?)\*{0,2}\s*(?::|=|-)\s*(.+)$", RegexOptions.Compiled);
+            new Regex(@"^\s*\*{0,2}([^:=\-\n]+?)\*{0,2}\s*(?::|=|-)\s*(.+)$", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         // Pre-compiled regex for ExtractCodeBlocks
         private static readonly Regex CodeBlockPattern =
-            new Regex(@"```(\w*)\s*\n([\s\S]*?)```", RegexOptions.Compiled | RegexOptions.Multiline);
+            new Regex(@"```(\w*)\s*\n([\s\S]*?)```", RegexOptions.Compiled | RegexOptions.Multiline, TimeSpan.FromMilliseconds(500));
 
         // Pre-compiled regex for ExtractSections (markdown header detection)
         private static readonly Regex SectionHeaderPattern =
-            new Regex(@"^(#{1,6})\s+(.+)$", RegexOptions.Compiled | RegexOptions.Multiline);
+            new Regex(@"^(#{1,6})\s+(.+)$", RegexOptions.Compiled | RegexOptions.Multiline, TimeSpan.FromMilliseconds(500));
 
         // Pre-compiled regex for markdown table separator detection
         private static readonly Regex TableSeparatorPattern =
-            new Regex(@"^\|[\s\-:]+(\|[\s\-:]+)*\|$", RegexOptions.Compiled);
+            new Regex(@"^\|[\s\-:]+(\|[\s\-:]+)*\|$", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
         // ═══════════════════════════════════════════════════════
         // JSON Extraction
@@ -608,7 +608,7 @@ namespace Prompt
         internal static string? ExtractFencedBlock(string response, string? language)
         {
             string langPattern = string.IsNullOrEmpty(language) ? @"\w*" : Regex.Escape(language);
-            var pattern = new Regex($@"```{langPattern}\s*\n([\s\S]*?)```", RegexOptions.Multiline);
+            var pattern = new Regex($@"```{langPattern}\s*\n([\s\S]*?)```", RegexOptions.Multiline, TimeSpan.FromMilliseconds(500));
             var match = pattern.Match(response);
             return match.Success ? match.Groups[1].Value.Trim() : null;
         }


### PR DESCRIPTION
Fixes #46

Adds \TimeSpan.FromMilliseconds(500)\ to **262 unprotected Regex calls** across **32 source files**, preventing ReDoS (Regular Expression Denial of Service) from catastrophic backtracking on crafted input.

Several files process user-supplied prompt text, making this a real security concern:
- \PromptMigrationAssistant\ (52 calls)
- \PromptMinifier\ (40 calls)
- \PromptTokenOptimizer\ (28 calls)
- \PromptResponseEvaluator\ (25 calls)
- \PromptComplianceChecker\ (21 calls)

Follows the existing pattern from \PromptGuard.cs\ and \PromptDebugger.cs\ (which already used timeouts). Instance Regex objects with constructor-level timeouts are left unchanged.

**Build:** 0 errors, 0 warnings
**Tests:** 3359 passed (4 pre-existing failures unchanged)