### PR TITLE
refactor: deduplicate cost estimation logic in PromptCostEstimator

### DIFF
--- a/src/PromptCostEstimator.cs
+++ b/src/PromptCostEstimator.cs
@@ -273,12 +273,34 @@ namespace Prompt
         public CostReport Estimate(string promptText, int estimatedOutputTokens = DefaultOutputTokens)
         {
             ArgumentNullException.ThrowIfNull(promptText);
+            var inputTokens = PromptGuard.EstimateTokens(promptText);
+            return BuildCostReport(promptText, inputTokens, estimatedOutputTokens);
+        }
+
+        /// <summary>
+        /// Estimate cost for a pre-counted token amount (when you already know the token count).
+        /// </summary>
+        /// <param name="inputTokens">Known input token count.</param>
+        /// <param name="estimatedOutputTokens">Expected output length in tokens.</param>
+        /// <returns>A <see cref="CostReport"/> with per-model estimates.</returns>
+        public CostReport EstimateFromTokens(int inputTokens, int estimatedOutputTokens = DefaultOutputTokens)
+        {
+            if (inputTokens < 0)
+                throw new ArgumentException("Input tokens cannot be negative.");
+            return BuildCostReport("", inputTokens, estimatedOutputTokens);
+        }
+
+        /// <summary>
+        /// Core estimation logic shared by <see cref="Estimate"/> and
+        /// <see cref="EstimateFromTokens"/>. Builds per-model cost estimates
+        /// and returns them sorted by total cost (cheapest first).
+        /// </summary>
+        private CostReport BuildCostReport(string promptText, int inputTokens, int estimatedOutputTokens)
+        {
             if (estimatedOutputTokens < 0)
                 throw new ArgumentException("Estimated output tokens cannot be negative.");
             if (estimatedOutputTokens > MaxOutputTokens)
                 throw new ArgumentException($"Estimated output tokens cannot exceed {MaxOutputTokens}.");
-
-            var inputTokens = PromptGuard.EstimateTokens(promptText);
 
             var estimates = new List<CostEstimate>();
 
@@ -318,65 +340,6 @@ namespace Prompt
             return new CostReport
             {
                 PromptText = promptText,
-                InputTokens = inputTokens,
-                EstimatedOutputTokens = estimatedOutputTokens,
-                Estimates = estimates
-            };
-        }
-
-        /// <summary>
-        /// Estimate cost for a pre-counted token amount (when you already know the token count).
-        /// </summary>
-        /// <param name="inputTokens">Known input token count.</param>
-        /// <param name="estimatedOutputTokens">Expected output length in tokens.</param>
-        /// <returns>A <see cref="CostReport"/> with per-model estimates.</returns>
-        public CostReport EstimateFromTokens(int inputTokens, int estimatedOutputTokens = DefaultOutputTokens)
-        {
-            if (inputTokens < 0)
-                throw new ArgumentException("Input tokens cannot be negative.");
-            if (estimatedOutputTokens < 0)
-                throw new ArgumentException("Estimated output tokens cannot be negative.");
-            if (estimatedOutputTokens > MaxOutputTokens)
-                throw new ArgumentException($"Estimated output tokens cannot exceed {MaxOutputTokens}.");
-
-            var estimates = new List<CostEstimate>();
-
-            foreach (var model in _models)
-            {
-                var totalInputNeeded = inputTokens + estimatedOutputTokens;
-                var exceedsContext = totalInputNeeded > model.ContextWindow;
-                var contextUsage = model.ContextWindow > 0
-                    ? (double)totalInputNeeded / model.ContextWindow * 100
-                    : 100.0;
-
-                var cappedOutput = Math.Min(estimatedOutputTokens, model.MaxOutputTokens);
-                var inputCost = model.InputCost(inputTokens);
-                var outputCost = model.OutputCost(cappedOutput);
-
-                string? warning = null;
-                if (!exceedsContext && contextUsage > 80)
-                    warning = "Context window usage above 80%";
-                if (estimatedOutputTokens > model.MaxOutputTokens)
-                    warning = $"Output capped to model max ({model.MaxOutputTokens})";
-
-                estimates.Add(new CostEstimate(
-                    Model: model,
-                    InputTokens: inputTokens,
-                    EstimatedOutputTokens: cappedOutput,
-                    InputCost: inputCost,
-                    OutputCost: outputCost,
-                    TotalCost: inputCost + outputCost,
-                    ContextUsagePercent: contextUsage,
-                    ExceedsContext: exceedsContext,
-                    Warning: warning
-                ));
-            }
-
-            estimates.Sort((a, b) => a.TotalCost.CompareTo(b.TotalCost));
-
-            return new CostReport
-            {
-                PromptText = "",
                 InputTokens = inputTokens,
                 EstimatedOutputTokens = estimatedOutputTokens,
                 Estimates = estimates


### PR DESCRIPTION
## What

Extracted the shared per-model cost estimation loop from \Estimate()\ and \EstimateFromTokens()\ into a private \BuildCostReport()\ method.

## Why

Both methods had ~30 identical lines building cost estimates per model. Any future change (new warning conditions, different sorting, etc.) would need to be applied twice.

## Changes

- New private \BuildCostReport(string, int, int)\ method with the shared logic
- \Estimate()\ now calls \BuildCostReport()\ after resolving token count from text
- \EstimateFromTokens()\ now calls \BuildCostReport()\ directly
- No behavioral changes — same validation, same output