### PR TITLE
refactor: consolidate 4 duplicate EstimateTokens implementations → delegate to PromptGuard

### DIFF
--- a/src/PromptContextCompressor.cs
+++ b/src/PromptContextCompressor.cs
@@ -599,11 +599,8 @@ namespace Prompt
 
         // --- Helpers ---
 
-        private static int EstimateTokens(string text)
-        {
-            if (string.IsNullOrEmpty(text)) return 0;
-            return (int)Math.Ceiling(text.Length / 4.0);
-        }
+        private static int EstimateTokens(string text) =>
+            PromptGuard.EstimateTokens(text);
 
         private bool FitsInBudgetInternal(List<(string Role, string Content)> messages)
         {

--- a/src/PromptHistory.cs
+++ b/src/PromptHistory.cs
@@ -387,7 +387,7 @@ namespace Prompt
         /// Rough token estimate (~4 chars per token for English text).
         /// </summary>
         internal static int EstimateTokens(string text) =>
-            string.IsNullOrEmpty(text) ? 0 : (int)Math.Ceiling(text.Length / 4.0);
+            PromptGuard.EstimateTokens(text);
 
         private static double Median(double[] sorted)
         {

--- a/src/PromptMetadataExtractor.cs
+++ b/src/PromptMetadataExtractor.cs
@@ -282,13 +282,8 @@ namespace Prompt
 
         // ── Internals ────────────────────────────────────────────────
 
-        private static int EstimateTokens(string text)
-        {
-            var words = text.Split(new[] { ' ', '\t', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries).Length;
-            var cjk = text.Count(c => (c >= 0x4E00 && c <= 0x9FFF) || (c >= 0x3040 && c <= 0x309F) ||
-                                      (c >= 0x30A0 && c <= 0x30FF) || (c >= 0xAC00 && c <= 0xD7AF));
-            return (int)(words / 0.75) + (int)(cjk / 1.5);
-        }
+        private static int EstimateTokens(string text) =>
+            PromptGuard.EstimateTokens(text);
 
         private static DetectedLanguage DetectLanguage(string text)
         {

--- a/src/PromptTokenOptimizer.cs
+++ b/src/PromptTokenOptimizer.cs
@@ -445,12 +445,8 @@ namespace Prompt
 
         // --- Internal methods ---
 
-        internal static int EstimateTokens(string text)
-        {
-            if (string.IsNullOrEmpty(text)) return 0;
-            // Rough GPT-style estimate: ~4 chars per token on average
-            return Math.Max(1, (int)Math.Ceiling(text.Length / 4.0));
-        }
+        internal static int EstimateTokens(string text) =>
+            PromptGuard.EstimateTokens(text);
 
         internal List<PromptSection> IdentifySections(string prompt, int totalTokens)
         {


### PR DESCRIPTION
**Problem:** 4 files had their own simplified \EstimateTokens\ methods (basic \	ext.Length / 4.0\) while \PromptGuard.EstimateTokens\ had the canonical version with word count blending, code-content detection, and newline adjustment.

**Fix:** Replaced duplicate bodies with one-line delegation to \PromptGuard.EstimateTokens\:
- \PromptContextCompressor.cs\ — was \Ceiling(text.Length / 4.0)\
- \PromptHistory.cs\ — was \Ceiling(text.Length / 4.0)\
- \PromptTokenOptimizer.cs\ — was \Max(1, Ceiling(text.Length / 4.0))\
- \PromptMetadataExtractor.cs\ — was custom CJK-aware version

**Kept as-is:**
- \Main.cs\ — takes \int charCount\ (different signature)
- \PromptABTester.cs\ — already delegates correctly

**Benefits:** Single source of truth for token estimation; all callers get code-aware + word-count-blended estimates; easier to upgrade logic in one place.

534 tests pass, 0 failures.