### PR TITLE
ci: enforce 50% line coverage threshold + PR coverage summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,32 @@ jobs:
             -c Release \
             --logger "trx;LogFileName=results.trx" \
             /p:CollectCoverage=true \
-            /p:CoverletOutputFormat=cobertura \
+            /p:CoverletOutputFormat="cobertura%2cjson" \
             /p:CoverletOutput=./coverage/ \
             /p:Include="[Prompt]*" \
-            /p:ExcludeByAttribute="GeneratedCodeAttribute"
+            /p:ExcludeByAttribute="GeneratedCodeAttribute" \
+            /p:Threshold=50 \
+            /p:ThresholdType=line \
+            /p:ThresholdStat=total
+
+      - name: Generate coverage summary
+        if: always()
+        run: |
+          if [ -f tests/coverage/coverage.cobertura.xml ]; then
+            LINE_RATE=$(grep -oP 'line-rate="\K[^"]+' tests/coverage/coverage.cobertura.xml | head -1)
+            if [ -n "$LINE_RATE" ]; then
+              PCT=$(echo "$LINE_RATE * 100" | bc -l | xargs printf "%.1f")
+              {
+                echo "## Coverage Summary"
+                echo ""
+                echo "| Metric | Value |"
+                echo "|--------|-------|"
+                echo "| Line coverage | ${PCT}% |"
+                echo "| Threshold | 50% (line) |"
+                echo ""
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
 
       - name: Upload coverage to Codecov
         if: github.event_name == 'push'


### PR DESCRIPTION
**Problem:** Coverage was collected and uploaded to Codecov, but there was no enforcement — coverage could silently regress without CI catching it.

**Changes:**

**Coverage threshold enforcement:**
- Added \/p:Threshold=50\ — CI fails if total line coverage drops below 50%
- Uses \/p:ThresholdType=line\ and \/p:ThresholdStat=total\
- Threshold is conservative (50%) to avoid false failures while catching major regressions

**Coverage summary in PR checks:**
- New step parses cobertura XML and writes a coverage summary table to GitHub Step Summary
- Visible directly in PR check details — no need to visit Codecov

**Dual output format:**
- Now generates both cobertura (for Codecov) and JSON (for local tooling) reports