### PR TITLE
feat: PromptReplayRecorder — VCR-style prompt interaction recording and replay

### DIFF
--- a/src/PromptReplayRecorder.cs
+++ b/src/PromptReplayRecorder.cs
@@ -1,0 +1,742 @@
+namespace Prompt
+{
+    using System.Security.Cryptography;
+    using System.Text;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// A recorded prompt interaction (request + response + metadata).
+    /// </summary>
+    public class RecordedInteraction
+    {
+        /// <summary>Unique identifier for this recording.</summary>
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = Guid.NewGuid().ToString("N")[..12];
+
+        /// <summary>The prompt text sent to the model.</summary>
+        [JsonPropertyName("prompt")]
+        public string Prompt { get; set; } = "";
+
+        /// <summary>The system prompt, if any.</summary>
+        [JsonPropertyName("systemPrompt")]
+        public string? SystemPrompt { get; set; }
+
+        /// <summary>The model response text.</summary>
+        [JsonPropertyName("response")]
+        public string Response { get; set; } = "";
+
+        /// <summary>Model identifier (e.g. "gpt-4", "claude-3-opus").</summary>
+        [JsonPropertyName("model")]
+        public string Model { get; set; } = "";
+
+        /// <summary>Response latency in milliseconds.</summary>
+        [JsonPropertyName("latencyMs")]
+        public long LatencyMs { get; set; }
+
+        /// <summary>Input token count.</summary>
+        [JsonPropertyName("inputTokens")]
+        public int InputTokens { get; set; }
+
+        /// <summary>Output token count.</summary>
+        [JsonPropertyName("outputTokens")]
+        public int OutputTokens { get; set; }
+
+        /// <summary>Estimated cost in USD.</summary>
+        [JsonPropertyName("estimatedCostUsd")]
+        public double EstimatedCostUsd { get; set; }
+
+        /// <summary>UTC timestamp when the interaction was recorded.</summary>
+        [JsonPropertyName("timestamp")]
+        public DateTimeOffset Timestamp { get; set; } = DateTimeOffset.UtcNow;
+
+        /// <summary>Optional tags for filtering/grouping.</summary>
+        [JsonPropertyName("tags")]
+        public List<string> Tags { get; set; } = new();
+
+        /// <summary>Optional key-value metadata.</summary>
+        [JsonPropertyName("metadata")]
+        public Dictionary<string, string> Metadata { get; set; } = new();
+
+        /// <summary>Temperature setting used.</summary>
+        [JsonPropertyName("temperature")]
+        public double? Temperature { get; set; }
+
+        /// <summary>Whether this interaction resulted in an error.</summary>
+        [JsonPropertyName("isError")]
+        public bool IsError { get; set; }
+
+        /// <summary>Error message if IsError is true.</summary>
+        [JsonPropertyName("errorMessage")]
+        public string? ErrorMessage { get; set; }
+
+        /// <summary>
+        /// Content-based fingerprint for matching during replay.
+        /// Computed from prompt + systemPrompt + model.
+        /// </summary>
+        [JsonPropertyName("fingerprint")]
+        public string Fingerprint { get; set; } = "";
+
+        /// <summary>Compute the content fingerprint for this interaction.</summary>
+        internal void ComputeFingerprint()
+        {
+            var input = $"{Prompt}|{SystemPrompt ?? ""}|{Model}";
+            using var sha = SHA256.Create();
+            var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(input));
+            Fingerprint = Convert.ToHexString(hash)[..16].ToLowerInvariant();
+        }
+    }
+
+    /// <summary>
+    /// A cassette containing a sequence of recorded interactions.
+    /// Named after VCR cassettes — record once, replay many times.
+    /// </summary>
+    public class Cassette
+    {
+        /// <summary>Cassette name/identifier.</summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        /// <summary>When this cassette was created.</summary>
+        [JsonPropertyName("createdAt")]
+        public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+        /// <summary>Human-readable description.</summary>
+        [JsonPropertyName("description")]
+        public string Description { get; set; } = "";
+
+        /// <summary>The recorded interactions in order.</summary>
+        [JsonPropertyName("interactions")]
+        public List<RecordedInteraction> Interactions { get; set; } = new();
+
+        /// <summary>Cassette-level tags.</summary>
+        [JsonPropertyName("tags")]
+        public List<string> Tags { get; set; } = new();
+
+        /// <summary>Schema version for forward compatibility.</summary>
+        [JsonPropertyName("version")]
+        public int Version { get; set; } = 1;
+    }
+
+    /// <summary>
+    /// Result of a replay operation.
+    /// </summary>
+    public class ReplayResult
+    {
+        /// <summary>The matched recorded interaction (null if miss).</summary>
+        public RecordedInteraction? Recording { get; set; }
+
+        /// <summary>Whether a matching recording was found.</summary>
+        public bool IsHit => Recording != null;
+
+        /// <summary>The fingerprint used for matching.</summary>
+        public string Fingerprint { get; set; } = "";
+
+        /// <summary>Match strategy that found the recording.</summary>
+        public string MatchStrategy { get; set; } = "";
+    }
+
+    /// <summary>
+    /// Replay matching strategy.
+    /// </summary>
+    public enum ReplayMatchStrategy
+    {
+        /// <summary>Exact match on prompt + systemPrompt + model (fingerprint).</summary>
+        Exact,
+
+        /// <summary>Match on prompt + systemPrompt only (ignore model).</summary>
+        PromptOnly,
+
+        /// <summary>Sequential — replay in recording order regardless of content.</summary>
+        Sequential
+    }
+
+    /// <summary>
+    /// Statistics for replay operations.
+    /// </summary>
+    public class ReplayStats
+    {
+        /// <summary>Total replay attempts.</summary>
+        public int TotalAttempts { get; internal set; }
+
+        /// <summary>Successful matches.</summary>
+        public int Hits { get; internal set; }
+
+        /// <summary>Failed matches.</summary>
+        public int Misses { get; internal set; }
+
+        /// <summary>Hit rate as percentage.</summary>
+        public double HitRate => TotalAttempts == 0 ? 0 : Math.Round((double)Hits / TotalAttempts * 100, 2);
+
+        /// <summary>Total tokens replayed (input + output).</summary>
+        public long TotalTokensReplayed { get; internal set; }
+
+        /// <summary>Total estimated cost saved by replaying.</summary>
+        public double EstimatedCostSaved { get; internal set; }
+
+        /// <summary>Total latency saved (sum of original latencies).</summary>
+        public long LatencySavedMs { get; internal set; }
+    }
+
+    /// <summary>
+    /// VCR-style prompt interaction recorder and replayer.
+    ///
+    /// <para>Records prompt interactions (input/output/model/latency/tokens) into
+    /// named cassettes, then replays them for debugging, regression testing,
+    /// or cost estimation — without hitting the LLM API.</para>
+    ///
+    /// <para>Inspired by Ruby's VCR gem and Python's vcrpy for HTTP cassettes,
+    /// but designed specifically for LLM prompt interactions.</para>
+    ///
+    /// <example>
+    /// <code>
+    /// // Record
+    /// var recorder = new PromptReplayRecorder();
+    /// recorder.StartRecording("my-test-session");
+    /// recorder.Record(new RecordedInteraction {
+    ///     Prompt = "What is 2+2?",
+    ///     Response = "4",
+    ///     Model = "gpt-4",
+    ///     LatencyMs = 320,
+    ///     InputTokens = 12,
+    ///     OutputTokens = 1
+    /// });
+    /// recorder.StopRecording();
+    ///
+    /// // Replay
+    /// recorder.LoadCassette("my-test-session");
+    /// var result = recorder.Replay("What is 2+2?", model: "gpt-4");
+    /// // result.Recording.Response == "4", no API call needed
+    ///
+    /// // Export/Import
+    /// string json = recorder.ExportCassette("my-test-session");
+    /// recorder.ImportCassette(json);
+    /// </code>
+    /// </example>
+    /// </summary>
+    public class PromptReplayRecorder
+    {
+        private readonly Dictionary<string, Cassette> _cassettes = new();
+        private Cassette? _activeCassette;
+        private string? _activeCassetteName;
+        private bool _isRecording;
+        private int _sequentialIndex;
+        private ReplayMatchStrategy _defaultStrategy;
+        private readonly ReplayStats _stats = new();
+        private readonly object _lock = new();
+
+        /// <summary>
+        /// Creates a new PromptReplayRecorder with the specified default match strategy.
+        /// </summary>
+        /// <param name="defaultStrategy">Default matching strategy for replay operations.</param>
+        public PromptReplayRecorder(ReplayMatchStrategy defaultStrategy = ReplayMatchStrategy.Exact)
+        {
+            _defaultStrategy = defaultStrategy;
+        }
+
+        // ── Recording ─────────────────────────────────────────────
+
+        /// <summary>
+        /// Start recording interactions into a named cassette.
+        /// Creates a new cassette or appends to an existing one.
+        /// </summary>
+        /// <param name="cassetteName">Name for the cassette.</param>
+        /// <param name="description">Optional description.</param>
+        /// <param name="append">If true, append to existing cassette; if false, overwrite.</param>
+        /// <exception cref="ArgumentException">If cassetteName is null or empty.</exception>
+        /// <exception cref="InvalidOperationException">If already recording.</exception>
+        public void StartRecording(string cassetteName, string? description = null, bool append = false)
+        {
+            if (string.IsNullOrWhiteSpace(cassetteName))
+                throw new ArgumentException("Cassette name cannot be null or empty.", nameof(cassetteName));
+
+            lock (_lock)
+            {
+                if (_isRecording)
+                    throw new InvalidOperationException(
+                        $"Already recording to cassette '{_activeCassetteName}'. Call StopRecording() first.");
+
+                if (!append || !_cassettes.ContainsKey(cassetteName))
+                {
+                    _cassettes[cassetteName] = new Cassette
+                    {
+                        Name = cassetteName,
+                        Description = description ?? ""
+                    };
+                }
+                else if (description != null)
+                {
+                    _cassettes[cassetteName].Description = description;
+                }
+
+                _activeCassette = _cassettes[cassetteName];
+                _activeCassetteName = cassetteName;
+                _isRecording = true;
+            }
+        }
+
+        /// <summary>
+        /// Record a prompt interaction into the active cassette.
+        /// </summary>
+        /// <param name="interaction">The interaction to record.</param>
+        /// <exception cref="InvalidOperationException">If not currently recording.</exception>
+        /// <exception cref="ArgumentNullException">If interaction is null.</exception>
+        public void Record(RecordedInteraction interaction)
+        {
+            if (interaction == null) throw new ArgumentNullException(nameof(interaction));
+
+            lock (_lock)
+            {
+                if (!_isRecording || _activeCassette == null)
+                    throw new InvalidOperationException("Not recording. Call StartRecording() first.");
+
+                interaction.ComputeFingerprint();
+                _activeCassette.Interactions.Add(interaction);
+            }
+        }
+
+        /// <summary>
+        /// Stop recording and finalize the cassette.
+        /// </summary>
+        /// <returns>The completed cassette.</returns>
+        /// <exception cref="InvalidOperationException">If not currently recording.</exception>
+        public Cassette StopRecording()
+        {
+            lock (_lock)
+            {
+                if (!_isRecording || _activeCassette == null)
+                    throw new InvalidOperationException("Not recording.");
+
+                var cassette = _activeCassette;
+                _activeCassette = null;
+                _activeCassetteName = null;
+                _isRecording = false;
+                return cassette;
+            }
+        }
+
+        /// <summary>Whether the recorder is currently in recording mode.</summary>
+        public bool IsRecording
+        {
+            get { lock (_lock) { return _isRecording; } }
+        }
+
+        /// <summary>Name of the cassette currently being recorded to.</summary>
+        public string? ActiveCassetteName
+        {
+            get { lock (_lock) { return _activeCassetteName; } }
+        }
+
+        // ── Replay ────────────────────────────────────────────────
+
+        /// <summary>
+        /// Load a cassette for replay and reset the sequential index.
+        /// </summary>
+        /// <param name="cassetteName">Name of the cassette to load.</param>
+        /// <exception cref="KeyNotFoundException">If cassette doesn't exist.</exception>
+        public void LoadCassette(string cassetteName)
+        {
+            lock (_lock)
+            {
+                if (!_cassettes.ContainsKey(cassetteName))
+                    throw new KeyNotFoundException($"Cassette '{cassetteName}' not found.");
+
+                _activeCassette = _cassettes[cassetteName];
+                _activeCassetteName = cassetteName;
+                _sequentialIndex = 0;
+            }
+        }
+
+        /// <summary>
+        /// Replay a prompt interaction from the loaded cassette.
+        /// </summary>
+        /// <param name="prompt">The prompt to match.</param>
+        /// <param name="systemPrompt">Optional system prompt to match.</param>
+        /// <param name="model">Optional model to match.</param>
+        /// <param name="strategy">Override the default match strategy.</param>
+        /// <returns>ReplayResult with the matched recording or a miss.</returns>
+        /// <exception cref="InvalidOperationException">If no cassette is loaded.</exception>
+        public ReplayResult Replay(string prompt, string? systemPrompt = null,
+                                    string? model = null, ReplayMatchStrategy? strategy = null)
+        {
+            lock (_lock)
+            {
+                if (_activeCassette == null)
+                    throw new InvalidOperationException("No cassette loaded. Call LoadCassette() first.");
+
+                var strat = strategy ?? _defaultStrategy;
+                _stats.TotalAttempts++;
+
+                RecordedInteraction? match = null;
+                string fingerprint = "";
+                string strategyName = strat.ToString();
+
+                switch (strat)
+                {
+                    case ReplayMatchStrategy.Exact:
+                        fingerprint = ComputeFingerprint(prompt, systemPrompt, model ?? "");
+                        match = _activeCassette.Interactions
+                            .FirstOrDefault(i => i.Fingerprint == fingerprint);
+                        break;
+
+                    case ReplayMatchStrategy.PromptOnly:
+                        fingerprint = ComputeFingerprint(prompt, systemPrompt, "");
+                        // Match on prompt + systemPrompt, ignore model
+                        match = _activeCassette.Interactions
+                            .FirstOrDefault(i =>
+                                i.Prompt == prompt &&
+                                (i.SystemPrompt ?? "") == (systemPrompt ?? ""));
+                        break;
+
+                    case ReplayMatchStrategy.Sequential:
+                        if (_sequentialIndex < _activeCassette.Interactions.Count)
+                        {
+                            match = _activeCassette.Interactions[_sequentialIndex];
+                            _sequentialIndex++;
+                        }
+                        fingerprint = $"seq:{_sequentialIndex - 1}";
+                        strategyName = "Sequential";
+                        break;
+                }
+
+                if (match != null)
+                {
+                    _stats.Hits++;
+                    _stats.TotalTokensReplayed += match.InputTokens + match.OutputTokens;
+                    _stats.EstimatedCostSaved += match.EstimatedCostUsd;
+                    _stats.LatencySavedMs += match.LatencyMs;
+                }
+                else
+                {
+                    _stats.Misses++;
+                }
+
+                return new ReplayResult
+                {
+                    Recording = match,
+                    Fingerprint = fingerprint,
+                    MatchStrategy = strategyName
+                };
+            }
+        }
+
+        /// <summary>
+        /// Reset the sequential replay index to the beginning.
+        /// </summary>
+        public void ResetSequentialIndex()
+        {
+            lock (_lock) { _sequentialIndex = 0; }
+        }
+
+        // ── Cassette Management ───────────────────────────────────
+
+        /// <summary>Get the names of all stored cassettes.</summary>
+        public List<string> ListCassettes()
+        {
+            lock (_lock) { return _cassettes.Keys.OrderBy(k => k).ToList(); }
+        }
+
+        /// <summary>Get a cassette by name.</summary>
+        /// <param name="cassetteName">The cassette name.</param>
+        /// <returns>The cassette, or null if not found.</returns>
+        public Cassette? GetCassette(string cassetteName)
+        {
+            lock (_lock)
+            {
+                return _cassettes.TryGetValue(cassetteName, out var c) ? c : null;
+            }
+        }
+
+        /// <summary>Remove a cassette.</summary>
+        /// <param name="cassetteName">The cassette name.</param>
+        /// <returns>True if removed, false if not found.</returns>
+        public bool RemoveCassette(string cassetteName)
+        {
+            lock (_lock)
+            {
+                if (_activeCassetteName == cassetteName)
+                {
+                    _activeCassette = null;
+                    _activeCassetteName = null;
+                    _isRecording = false;
+                }
+                return _cassettes.Remove(cassetteName);
+            }
+        }
+
+        /// <summary>Remove all cassettes and reset state.</summary>
+        public void Clear()
+        {
+            lock (_lock)
+            {
+                _cassettes.Clear();
+                _activeCassette = null;
+                _activeCassetteName = null;
+                _isRecording = false;
+                _sequentialIndex = 0;
+            }
+        }
+
+        /// <summary>Total number of stored cassettes.</summary>
+        public int CassetteCount
+        {
+            get { lock (_lock) { return _cassettes.Count; } }
+        }
+
+        // ── Tags ──────────────────────────────────────────────────
+
+        /// <summary>
+        /// Add a tag to a cassette.
+        /// </summary>
+        public void TagCassette(string cassetteName, string tag)
+        {
+            lock (_lock)
+            {
+                if (!_cassettes.TryGetValue(cassetteName, out var c))
+                    throw new KeyNotFoundException($"Cassette '{cassetteName}' not found.");
+                if (!c.Tags.Contains(tag))
+                    c.Tags.Add(tag);
+            }
+        }
+
+        /// <summary>
+        /// Find cassettes by tag.
+        /// </summary>
+        public List<string> FindByTag(string tag)
+        {
+            lock (_lock)
+            {
+                return _cassettes
+                    .Where(kv => kv.Value.Tags.Contains(tag))
+                    .Select(kv => kv.Key)
+                    .OrderBy(k => k)
+                    .ToList();
+            }
+        }
+
+        // ── Export / Import ────────────────────────────────────────
+
+        /// <summary>
+        /// Export a cassette as a JSON string.
+        /// </summary>
+        /// <param name="cassetteName">The cassette to export.</param>
+        /// <returns>JSON string representation.</returns>
+        /// <exception cref="KeyNotFoundException">If cassette doesn't exist.</exception>
+        public string ExportCassette(string cassetteName)
+        {
+            lock (_lock)
+            {
+                if (!_cassettes.TryGetValue(cassetteName, out var cassette))
+                    throw new KeyNotFoundException($"Cassette '{cassetteName}' not found.");
+
+                return JsonSerializer.Serialize(cassette, new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+                });
+            }
+        }
+
+        /// <summary>
+        /// Import a cassette from a JSON string.
+        /// </summary>
+        /// <param name="json">JSON string of a Cassette.</param>
+        /// <param name="overwrite">If true, overwrite existing cassette with same name.</param>
+        /// <returns>The imported cassette name.</returns>
+        /// <exception cref="ArgumentException">If JSON is invalid or cassette name is empty.</exception>
+        /// <exception cref="InvalidOperationException">If cassette exists and overwrite is false.</exception>
+        public string ImportCassette(string json, bool overwrite = false)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+                throw new ArgumentException("JSON cannot be null or empty.", nameof(json));
+
+            Cassette cassette;
+            try
+            {
+                cassette = JsonSerializer.Deserialize<Cassette>(json)
+                    ?? throw new ArgumentException("Deserialized cassette was null.");
+            }
+            catch (JsonException ex)
+            {
+                throw new ArgumentException($"Invalid cassette JSON: {ex.Message}", nameof(json), ex);
+            }
+
+            if (string.IsNullOrWhiteSpace(cassette.Name))
+                throw new ArgumentException("Cassette name cannot be empty.");
+
+            lock (_lock)
+            {
+                if (_cassettes.ContainsKey(cassette.Name) && !overwrite)
+                    throw new InvalidOperationException(
+                        $"Cassette '{cassette.Name}' already exists. Use overwrite: true to replace.");
+
+                // Recompute fingerprints
+                foreach (var interaction in cassette.Interactions)
+                    interaction.ComputeFingerprint();
+
+                _cassettes[cassette.Name] = cassette;
+                return cassette.Name;
+            }
+        }
+
+        /// <summary>
+        /// Export all cassettes as a JSON string.
+        /// </summary>
+        public string ExportAll()
+        {
+            lock (_lock)
+            {
+                var all = _cassettes.Values.ToList();
+                return JsonSerializer.Serialize(all, new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+                });
+            }
+        }
+
+        // ── Analysis ──────────────────────────────────────────────
+
+        /// <summary>
+        /// Get replay statistics.
+        /// </summary>
+        public ReplayStats GetStats()
+        {
+            lock (_lock)
+            {
+                return new ReplayStats
+                {
+                    TotalAttempts = _stats.TotalAttempts,
+                    Hits = _stats.Hits,
+                    Misses = _stats.Misses,
+                    TotalTokensReplayed = _stats.TotalTokensReplayed,
+                    EstimatedCostSaved = _stats.EstimatedCostSaved,
+                    LatencySavedMs = _stats.LatencySavedMs
+                };
+            }
+        }
+
+        /// <summary>
+        /// Get a summary of a cassette's contents.
+        /// </summary>
+        /// <param name="cassetteName">The cassette to summarize.</param>
+        /// <returns>Summary dictionary with interaction count, models, total tokens, etc.</returns>
+        public Dictionary<string, object> GetCassetteSummary(string cassetteName)
+        {
+            lock (_lock)
+            {
+                if (!_cassettes.TryGetValue(cassetteName, out var c))
+                    throw new KeyNotFoundException($"Cassette '{cassetteName}' not found.");
+
+                var models = c.Interactions.Select(i => i.Model).Where(m => !string.IsNullOrEmpty(m)).Distinct().ToList();
+                var totalInputTokens = c.Interactions.Sum(i => i.InputTokens);
+                var totalOutputTokens = c.Interactions.Sum(i => i.OutputTokens);
+                var totalCost = c.Interactions.Sum(i => i.EstimatedCostUsd);
+                var totalLatency = c.Interactions.Sum(i => i.LatencyMs);
+                var errorCount = c.Interactions.Count(i => i.IsError);
+                var allTags = c.Interactions.SelectMany(i => i.Tags).Distinct().OrderBy(t => t).ToList();
+
+                return new Dictionary<string, object>
+                {
+                    ["name"] = c.Name,
+                    ["description"] = c.Description,
+                    ["interactionCount"] = c.Interactions.Count,
+                    ["models"] = models,
+                    ["totalInputTokens"] = totalInputTokens,
+                    ["totalOutputTokens"] = totalOutputTokens,
+                    ["totalTokens"] = totalInputTokens + totalOutputTokens,
+                    ["totalEstimatedCostUsd"] = Math.Round(totalCost, 6),
+                    ["totalLatencyMs"] = totalLatency,
+                    ["avgLatencyMs"] = c.Interactions.Count > 0
+                        ? Math.Round((double)totalLatency / c.Interactions.Count, 1) : 0.0,
+                    ["errorCount"] = errorCount,
+                    ["tags"] = allTags,
+                    ["createdAt"] = c.CreatedAt.ToString("o")
+                };
+            }
+        }
+
+        /// <summary>
+        /// Compare two cassettes and return the differences.
+        /// Useful for regression testing — did the model outputs change?
+        /// </summary>
+        /// <param name="cassetteA">First cassette name.</param>
+        /// <param name="cassetteB">Second cassette name.</param>
+        /// <returns>List of comparison entries showing matches, mismatches, and missing items.</returns>
+        public List<Dictionary<string, object>> CompareCassettes(string cassetteA, string cassetteB)
+        {
+            lock (_lock)
+            {
+                if (!_cassettes.TryGetValue(cassetteA, out var a))
+                    throw new KeyNotFoundException($"Cassette '{cassetteA}' not found.");
+                if (!_cassettes.TryGetValue(cassetteB, out var b))
+                    throw new KeyNotFoundException($"Cassette '{cassetteB}' not found.");
+
+                var results = new List<Dictionary<string, object>>();
+                var bByFingerprint = b.Interactions
+                    .GroupBy(i => i.Fingerprint)
+                    .ToDictionary(g => g.Key, g => g.First());
+
+                var matchedFingerprints = new HashSet<string>();
+
+                foreach (var ia in a.Interactions)
+                {
+                    if (bByFingerprint.TryGetValue(ia.Fingerprint, out var ib))
+                    {
+                        matchedFingerprints.Add(ia.Fingerprint);
+                        var match = ia.Response == ib.Response;
+                        var entry = new Dictionary<string, object>
+                        {
+                            ["status"] = match ? "match" : "mismatch",
+                            ["fingerprint"] = ia.Fingerprint,
+                            ["prompt"] = ia.Prompt.Length > 80
+                                ? ia.Prompt[..80] + "..." : ia.Prompt,
+                            ["responseA"] = ia.Response.Length > 100
+                                ? ia.Response[..100] + "..." : ia.Response,
+                            ["responseB"] = ib.Response.Length > 100
+                                ? ib.Response[..100] + "..." : ib.Response,
+                            ["latencyDiffMs"] = ib.LatencyMs - ia.LatencyMs
+                        };
+                        results.Add(entry);
+                    }
+                    else
+                    {
+                        results.Add(new Dictionary<string, object>
+                        {
+                            ["status"] = "only_in_a",
+                            ["fingerprint"] = ia.Fingerprint,
+                            ["prompt"] = ia.Prompt.Length > 80
+                                ? ia.Prompt[..80] + "..." : ia.Prompt,
+                        });
+                    }
+                }
+
+                foreach (var ib in b.Interactions)
+                {
+                    if (!matchedFingerprints.Contains(ib.Fingerprint))
+                    {
+                        results.Add(new Dictionary<string, object>
+                        {
+                            ["status"] = "only_in_b",
+                            ["fingerprint"] = ib.Fingerprint,
+                            ["prompt"] = ib.Prompt.Length > 80
+                                ? ib.Prompt[..80] + "..." : ib.Prompt,
+                        });
+                    }
+                }
+
+                return results;
+            }
+        }
+
+        // ── Internal helpers ──────────────────────────────────────
+
+        private static string ComputeFingerprint(string prompt, string? systemPrompt, string model)
+        {
+            var input = $"{prompt}|{systemPrompt ?? ""}|{model}";
+            using var sha = SHA256.Create();
+            var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(input));
+            return Convert.ToHexString(hash)[..16].ToLowerInvariant();
+        }
+    }
+}

--- a/tests/PromptReplayRecorderTests.cs
+++ b/tests/PromptReplayRecorderTests.cs
@@ -1,0 +1,730 @@
+namespace Prompt.Tests
+{
+    using Prompt;
+    using Xunit;
+    using System.Text.Json;
+
+    public class PromptReplayRecorderTests
+    {
+        private RecordedInteraction MakeInteraction(
+            string prompt = "Hello",
+            string response = "Hi there",
+            string model = "gpt-4",
+            long latencyMs = 200,
+            int inputTokens = 10,
+            int outputTokens = 5,
+            double cost = 0.001)
+        {
+            return new RecordedInteraction
+            {
+                Prompt = prompt,
+                Response = response,
+                Model = model,
+                LatencyMs = latencyMs,
+                InputTokens = inputTokens,
+                OutputTokens = outputTokens,
+                EstimatedCostUsd = cost
+            };
+        }
+
+        // ── Construction ────────────────────────────────────────
+
+        [Fact]
+        public void Constructor_DefaultStrategy_Exact()
+        {
+            var recorder = new PromptReplayRecorder();
+            Assert.False(recorder.IsRecording);
+            Assert.Null(recorder.ActiveCassetteName);
+            Assert.Equal(0, recorder.CassetteCount);
+        }
+
+        [Fact]
+        public void Constructor_CustomStrategy()
+        {
+            var recorder = new PromptReplayRecorder(ReplayMatchStrategy.Sequential);
+            Assert.False(recorder.IsRecording);
+        }
+
+        // ── Recording ───────────────────────────────────────────
+
+        [Fact]
+        public void StartRecording_SetsActiveState()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("test-cassette", "A test");
+            Assert.True(recorder.IsRecording);
+            Assert.Equal("test-cassette", recorder.ActiveCassetteName);
+            Assert.Equal(1, recorder.CassetteCount);
+        }
+
+        [Fact]
+        public void StartRecording_EmptyName_Throws()
+        {
+            var recorder = new PromptReplayRecorder();
+            Assert.Throws<ArgumentException>(() => recorder.StartRecording(""));
+            Assert.Throws<ArgumentException>(() => recorder.StartRecording("  "));
+        }
+
+        [Fact]
+        public void StartRecording_WhileRecording_Throws()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("first");
+            Assert.Throws<InvalidOperationException>(() => recorder.StartRecording("second"));
+        }
+
+        [Fact]
+        public void StartRecording_Overwrite_ClearsExisting()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1");
+            recorder.Record(MakeInteraction());
+            recorder.StopRecording();
+
+            recorder.StartRecording("c1"); // overwrite (append=false default)
+            recorder.StopRecording();
+
+            var c = recorder.GetCassette("c1");
+            Assert.NotNull(c);
+            Assert.Empty(c!.Interactions);
+        }
+
+        [Fact]
+        public void StartRecording_Append_KeepsExisting()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1");
+            recorder.Record(MakeInteraction(prompt: "first"));
+            recorder.StopRecording();
+
+            recorder.StartRecording("c1", append: true);
+            recorder.Record(MakeInteraction(prompt: "second"));
+            recorder.StopRecording();
+
+            var c = recorder.GetCassette("c1");
+            Assert.Equal(2, c!.Interactions.Count);
+        }
+
+        [Fact]
+        public void Record_AddsInteraction()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1");
+            recorder.Record(MakeInteraction());
+            var cassette = recorder.StopRecording();
+
+            Assert.Single(cassette.Interactions);
+            Assert.NotEmpty(cassette.Interactions[0].Fingerprint);
+        }
+
+        [Fact]
+        public void Record_NullInteraction_Throws()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1");
+            Assert.Throws<ArgumentNullException>(() => recorder.Record(null!));
+        }
+
+        [Fact]
+        public void Record_WhenNotRecording_Throws()
+        {
+            var recorder = new PromptReplayRecorder();
+            Assert.Throws<InvalidOperationException>(() => recorder.Record(MakeInteraction()));
+        }
+
+        [Fact]
+        public void StopRecording_ReturnsCassette()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1");
+            recorder.Record(MakeInteraction());
+            var cassette = recorder.StopRecording();
+
+            Assert.Equal("c1", cassette.Name);
+            Assert.False(recorder.IsRecording);
+        }
+
+        [Fact]
+        public void StopRecording_WhenNotRecording_Throws()
+        {
+            var recorder = new PromptReplayRecorder();
+            Assert.Throws<InvalidOperationException>(() => recorder.StopRecording());
+        }
+
+        // ── Replay: Exact ───────────────────────────────────────
+
+        [Fact]
+        public void Replay_ExactMatch_Hit()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1");
+            recorder.Record(MakeInteraction(prompt: "What is 2+2?", response: "4", model: "gpt-4"));
+            recorder.StopRecording();
+
+            recorder.LoadCassette("c1");
+            var result = recorder.Replay("What is 2+2?", model: "gpt-4");
+
+            Assert.True(result.IsHit);
+            Assert.Equal("4", result.Recording!.Response);
+            Assert.Equal("Exact", result.MatchStrategy);
+        }
+
+        [Fact]
+        public void Replay_ExactMatch_DifferentModel_Miss()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1");
+            recorder.Record(MakeInteraction(prompt: "Hello", model: "gpt-4"));
+            recorder.StopRecording();
+
+            recorder.LoadCassette("c1");
+            var result = recorder.Replay("Hello", model: "claude-3");
+
+            Assert.False(result.IsHit);
+        }
+
+        [Fact]
+        public void Replay_ExactMatch_DifferentPrompt_Miss()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1");
+            recorder.Record(MakeInteraction(prompt: "Hello", model: "gpt-4"));
+            recorder.StopRecording();
+
+            recorder.LoadCassette("c1");
+            var result = recorder.Replay("Goodbye", model: "gpt-4");
+
+            Assert.False(result.IsHit);
+        }
+
+        // ── Replay: PromptOnly ──────────────────────────────────
+
+        [Fact]
+        public void Replay_PromptOnly_IgnoresModel()
+        {
+            var recorder = new PromptReplayRecorder(ReplayMatchStrategy.PromptOnly);
+            recorder.StartRecording("c1");
+            recorder.Record(MakeInteraction(prompt: "What is AI?", response: "Artificial Intelligence", model: "gpt-4"));
+            recorder.StopRecording();
+
+            recorder.LoadCassette("c1");
+            var result = recorder.Replay("What is AI?", model: "claude-3");
+
+            Assert.True(result.IsHit);
+            Assert.Equal("Artificial Intelligence", result.Recording!.Response);
+        }
+
+        [Fact]
+        public void Replay_PromptOnly_MatchesWithSystemPrompt()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1");
+            var interaction = MakeInteraction(prompt: "Hi", response: "Hello!");
+            interaction.SystemPrompt = "Be friendly";
+            recorder.Record(interaction);
+            recorder.StopRecording();
+
+            recorder.LoadCassette("c1");
+            var result = recorder.Replay("Hi", systemPrompt: "Be friendly",
+                strategy: ReplayMatchStrategy.PromptOnly);
+
+            Assert.True(result.IsHit);
+        }
+
+        // ── Replay: Sequential ──────────────────────────────────
+
+        [Fact]
+        public void Replay_Sequential_ReturnsInOrder()
+        {
+            var recorder = new PromptReplayRecorder(ReplayMatchStrategy.Sequential);
+            recorder.StartRecording("c1");
+            recorder.Record(MakeInteraction(prompt: "Q1", response: "A1"));
+            recorder.Record(MakeInteraction(prompt: "Q2", response: "A2"));
+            recorder.Record(MakeInteraction(prompt: "Q3", response: "A3"));
+            recorder.StopRecording();
+
+            recorder.LoadCassette("c1");
+            Assert.Equal("A1", recorder.Replay("anything").Recording!.Response);
+            Assert.Equal("A2", recorder.Replay("whatever").Recording!.Response);
+            Assert.Equal("A3", recorder.Replay("doesn't matter").Recording!.Response);
+        }
+
+        [Fact]
+        public void Replay_Sequential_MissAfterExhausted()
+        {
+            var recorder = new PromptReplayRecorder(ReplayMatchStrategy.Sequential);
+            recorder.StartRecording("c1");
+            recorder.Record(MakeInteraction());
+            recorder.StopRecording();
+
+            recorder.LoadCassette("c1");
+            recorder.Replay("a");
+            var result = recorder.Replay("b");
+
+            Assert.False(result.IsHit);
+        }
+
+        [Fact]
+        public void ResetSequentialIndex_RestartsFromBeginning()
+        {
+            var recorder = new PromptReplayRecorder(ReplayMatchStrategy.Sequential);
+            recorder.StartRecording("c1");
+            recorder.Record(MakeInteraction(response: "first"));
+            recorder.StopRecording();
+
+            recorder.LoadCassette("c1");
+            recorder.Replay("a");
+            recorder.ResetSequentialIndex();
+            var result = recorder.Replay("a");
+
+            Assert.True(result.IsHit);
+            Assert.Equal("first", result.Recording!.Response);
+        }
+
+        // ── Replay: no cassette loaded ──────────────────────────
+
+        [Fact]
+        public void Replay_NoCassetteLoaded_Throws()
+        {
+            var recorder = new PromptReplayRecorder();
+            Assert.Throws<InvalidOperationException>(() => recorder.Replay("hello"));
+        }
+
+        [Fact]
+        public void LoadCassette_Unknown_Throws()
+        {
+            var recorder = new PromptReplayRecorder();
+            Assert.Throws<KeyNotFoundException>(() => recorder.LoadCassette("nonexistent"));
+        }
+
+        // ── Strategy override ───────────────────────────────────
+
+        [Fact]
+        public void Replay_StrategyOverride()
+        {
+            var recorder = new PromptReplayRecorder(ReplayMatchStrategy.Exact);
+            recorder.StartRecording("c1");
+            recorder.Record(MakeInteraction(prompt: "Q", response: "A", model: "gpt-4"));
+            recorder.StopRecording();
+
+            recorder.LoadCassette("c1");
+            // Override to PromptOnly — should match even with different model
+            var result = recorder.Replay("Q", model: "claude-3",
+                strategy: ReplayMatchStrategy.PromptOnly);
+            Assert.True(result.IsHit);
+        }
+
+        // ── Cassette management ─────────────────────────────────
+
+        [Fact]
+        public void ListCassettes_SortedAlphabetically()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("charlie"); recorder.StopRecording();
+            recorder.StartRecording("alpha"); recorder.StopRecording();
+            recorder.StartRecording("bravo"); recorder.StopRecording();
+
+            var names = recorder.ListCassettes();
+            Assert.Equal(new[] { "alpha", "bravo", "charlie" }, names);
+        }
+
+        [Fact]
+        public void GetCassette_Unknown_ReturnsNull()
+        {
+            var recorder = new PromptReplayRecorder();
+            Assert.Null(recorder.GetCassette("nope"));
+        }
+
+        [Fact]
+        public void RemoveCassette_Succeeds()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1"); recorder.StopRecording();
+            Assert.True(recorder.RemoveCassette("c1"));
+            Assert.Equal(0, recorder.CassetteCount);
+        }
+
+        [Fact]
+        public void RemoveCassette_Unknown_ReturnsFalse()
+        {
+            var recorder = new PromptReplayRecorder();
+            Assert.False(recorder.RemoveCassette("nope"));
+        }
+
+        [Fact]
+        public void RemoveCassette_ActiveCassette_StopsRecording()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1");
+            recorder.RemoveCassette("c1");
+            Assert.False(recorder.IsRecording);
+        }
+
+        [Fact]
+        public void Clear_RemovesEverything()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1"); recorder.StopRecording();
+            recorder.StartRecording("c2"); recorder.StopRecording();
+            recorder.Clear();
+
+            Assert.Equal(0, recorder.CassetteCount);
+            Assert.False(recorder.IsRecording);
+        }
+
+        // ── Tags ────────────────────────────────────────────────
+
+        [Fact]
+        public void TagCassette_AddsTags()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1"); recorder.StopRecording();
+            recorder.TagCassette("c1", "regression");
+            recorder.TagCassette("c1", "v2");
+
+            var c = recorder.GetCassette("c1");
+            Assert.Contains("regression", c!.Tags);
+            Assert.Contains("v2", c.Tags);
+        }
+
+        [Fact]
+        public void TagCassette_DuplicateIgnored()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1"); recorder.StopRecording();
+            recorder.TagCassette("c1", "tag1");
+            recorder.TagCassette("c1", "tag1");
+
+            Assert.Single(recorder.GetCassette("c1")!.Tags);
+        }
+
+        [Fact]
+        public void FindByTag_ReturnsMatching()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1"); recorder.StopRecording();
+            recorder.StartRecording("c2"); recorder.StopRecording();
+            recorder.StartRecording("c3"); recorder.StopRecording();
+            recorder.TagCassette("c1", "regression");
+            recorder.TagCassette("c3", "regression");
+
+            var found = recorder.FindByTag("regression");
+            Assert.Equal(new[] { "c1", "c3" }, found);
+        }
+
+        [Fact]
+        public void FindByTag_NoMatch_ReturnsEmpty()
+        {
+            var recorder = new PromptReplayRecorder();
+            Assert.Empty(recorder.FindByTag("nonexistent"));
+        }
+
+        // ── Export / Import ─────────────────────────────────────
+
+        [Fact]
+        public void ExportImport_Roundtrip()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1", "test cassette");
+            recorder.Record(MakeInteraction(prompt: "Q", response: "A"));
+            recorder.StopRecording();
+
+            var json = recorder.ExportCassette("c1");
+            Assert.Contains("c1", json);
+            Assert.Contains("test cassette", json);
+
+            var recorder2 = new PromptReplayRecorder();
+            var name = recorder2.ImportCassette(json);
+            Assert.Equal("c1", name);
+
+            recorder2.LoadCassette("c1");
+            var result = recorder2.Replay("Q", model: "gpt-4");
+            Assert.True(result.IsHit);
+            Assert.Equal("A", result.Recording!.Response);
+        }
+
+        [Fact]
+        public void ExportCassette_Unknown_Throws()
+        {
+            var recorder = new PromptReplayRecorder();
+            Assert.Throws<KeyNotFoundException>(() => recorder.ExportCassette("nope"));
+        }
+
+        [Fact]
+        public void ImportCassette_EmptyJson_Throws()
+        {
+            var recorder = new PromptReplayRecorder();
+            Assert.Throws<ArgumentException>(() => recorder.ImportCassette(""));
+        }
+
+        [Fact]
+        public void ImportCassette_InvalidJson_Throws()
+        {
+            var recorder = new PromptReplayRecorder();
+            Assert.Throws<ArgumentException>(() => recorder.ImportCassette("not json"));
+        }
+
+        [Fact]
+        public void ImportCassette_DuplicateWithoutOverwrite_Throws()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1"); recorder.StopRecording();
+            var json = recorder.ExportCassette("c1");
+            Assert.Throws<InvalidOperationException>(() => recorder.ImportCassette(json));
+        }
+
+        [Fact]
+        public void ImportCassette_DuplicateWithOverwrite_Succeeds()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1");
+            recorder.Record(MakeInteraction());
+            recorder.StopRecording();
+
+            var json = recorder.ExportCassette("c1");
+            recorder.ImportCassette(json, overwrite: true);
+
+            Assert.Equal(1, recorder.CassetteCount);
+        }
+
+        [Fact]
+        public void ExportAll_IncludesAllCassettes()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1"); recorder.StopRecording();
+            recorder.StartRecording("c2"); recorder.StopRecording();
+
+            var json = recorder.ExportAll();
+            Assert.Contains("c1", json);
+            Assert.Contains("c2", json);
+        }
+
+        // ── Stats ───────────────────────────────────────────────
+
+        [Fact]
+        public void Stats_TrackHitsAndMisses()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1");
+            recorder.Record(MakeInteraction(prompt: "Hi", model: "gpt-4",
+                latencyMs: 300, inputTokens: 10, outputTokens: 5, cost: 0.01));
+            recorder.StopRecording();
+
+            recorder.LoadCassette("c1");
+            recorder.Replay("Hi", model: "gpt-4"); // hit
+            recorder.Replay("Bye", model: "gpt-4"); // miss
+
+            var stats = recorder.GetStats();
+            Assert.Equal(2, stats.TotalAttempts);
+            Assert.Equal(1, stats.Hits);
+            Assert.Equal(1, stats.Misses);
+            Assert.Equal(50.0, stats.HitRate);
+            Assert.Equal(15, stats.TotalTokensReplayed);
+            Assert.Equal(0.01, stats.EstimatedCostSaved);
+            Assert.Equal(300, stats.LatencySavedMs);
+        }
+
+        [Fact]
+        public void Stats_InitiallyEmpty()
+        {
+            var recorder = new PromptReplayRecorder();
+            var stats = recorder.GetStats();
+            Assert.Equal(0, stats.TotalAttempts);
+            Assert.Equal(0, stats.HitRate);
+        }
+
+        // ── Summary ─────────────────────────────────────────────
+
+        [Fact]
+        public void GetCassetteSummary_CorrectValues()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1", "test");
+            var i1 = MakeInteraction(prompt: "Q1", model: "gpt-4",
+                inputTokens: 100, outputTokens: 50, cost: 0.005, latencyMs: 200);
+            i1.Tags.Add("math");
+            recorder.Record(i1);
+            recorder.Record(MakeInteraction(prompt: "Q2", model: "claude-3",
+                inputTokens: 80, outputTokens: 30, cost: 0.003, latencyMs: 150));
+            recorder.StopRecording();
+
+            var summary = recorder.GetCassetteSummary("c1");
+            Assert.Equal("c1", summary["name"]);
+            Assert.Equal(2, summary["interactionCount"]);
+            Assert.Equal(260, summary["totalTokens"]);
+            Assert.Equal(Math.Round(0.008, 6), summary["totalEstimatedCostUsd"]);
+            Assert.Equal(350L, summary["totalLatencyMs"]);
+        }
+
+        [Fact]
+        public void GetCassetteSummary_Unknown_Throws()
+        {
+            var recorder = new PromptReplayRecorder();
+            Assert.Throws<KeyNotFoundException>(() => recorder.GetCassetteSummary("nope"));
+        }
+
+        // ── Compare ─────────────────────────────────────────────
+
+        [Fact]
+        public void CompareCassettes_MatchingResponses()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("v1");
+            recorder.Record(MakeInteraction(prompt: "Q1", response: "A1", model: "gpt-4"));
+            recorder.StopRecording();
+
+            recorder.StartRecording("v2");
+            recorder.Record(MakeInteraction(prompt: "Q1", response: "A1", model: "gpt-4"));
+            recorder.StopRecording();
+
+            var diff = recorder.CompareCassettes("v1", "v2");
+            Assert.Single(diff);
+            Assert.Equal("match", diff[0]["status"]);
+        }
+
+        [Fact]
+        public void CompareCassettes_MismatchedResponses()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("v1");
+            recorder.Record(MakeInteraction(prompt: "Q1", response: "Old answer", model: "gpt-4"));
+            recorder.StopRecording();
+
+            recorder.StartRecording("v2");
+            recorder.Record(MakeInteraction(prompt: "Q1", response: "New answer", model: "gpt-4"));
+            recorder.StopRecording();
+
+            var diff = recorder.CompareCassettes("v1", "v2");
+            Assert.Single(diff);
+            Assert.Equal("mismatch", diff[0]["status"]);
+        }
+
+        [Fact]
+        public void CompareCassettes_OnlyInA()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("v1");
+            recorder.Record(MakeInteraction(prompt: "Q1", model: "gpt-4"));
+            recorder.Record(MakeInteraction(prompt: "Q2", model: "gpt-4"));
+            recorder.StopRecording();
+
+            recorder.StartRecording("v2");
+            recorder.Record(MakeInteraction(prompt: "Q1", model: "gpt-4"));
+            recorder.StopRecording();
+
+            var diff = recorder.CompareCassettes("v1", "v2");
+            Assert.Equal(2, diff.Count);
+            Assert.Contains(diff, d => d["status"].ToString() == "only_in_a");
+        }
+
+        [Fact]
+        public void CompareCassettes_OnlyInB()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("v1");
+            recorder.Record(MakeInteraction(prompt: "Q1", model: "gpt-4"));
+            recorder.StopRecording();
+
+            recorder.StartRecording("v2");
+            recorder.Record(MakeInteraction(prompt: "Q1", model: "gpt-4"));
+            recorder.Record(MakeInteraction(prompt: "Q3", model: "gpt-4"));
+            recorder.StopRecording();
+
+            var diff = recorder.CompareCassettes("v1", "v2");
+            Assert.Contains(diff, d => d["status"].ToString() == "only_in_b");
+        }
+
+        [Fact]
+        public void CompareCassettes_Unknown_Throws()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("v1"); recorder.StopRecording();
+            Assert.Throws<KeyNotFoundException>(() => recorder.CompareCassettes("v1", "nope"));
+            Assert.Throws<KeyNotFoundException>(() => recorder.CompareCassettes("nope", "v1"));
+        }
+
+        // ── RecordedInteraction ─────────────────────────────────
+
+        [Fact]
+        public void RecordedInteraction_DefaultValues()
+        {
+            var i = new RecordedInteraction();
+            Assert.NotEmpty(i.Id);
+            Assert.Equal(12, i.Id.Length);
+            Assert.Equal("", i.Prompt);
+            Assert.Equal("", i.Response);
+            Assert.False(i.IsError);
+        }
+
+        [Fact]
+        public void RecordedInteraction_ErrorState()
+        {
+            var i = new RecordedInteraction
+            {
+                Prompt = "test",
+                IsError = true,
+                ErrorMessage = "Rate limited"
+            };
+            Assert.True(i.IsError);
+            Assert.Equal("Rate limited", i.ErrorMessage);
+        }
+
+        // ── Fingerprint determinism ─────────────────────────────
+
+        [Fact]
+        public void Fingerprint_SameInput_SameHash()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1");
+            recorder.Record(MakeInteraction(prompt: "test", model: "gpt-4"));
+            recorder.Record(MakeInteraction(prompt: "test", model: "gpt-4"));
+            var cassette = recorder.StopRecording();
+
+            Assert.Equal(cassette.Interactions[0].Fingerprint,
+                         cassette.Interactions[1].Fingerprint);
+        }
+
+        [Fact]
+        public void Fingerprint_DifferentInput_DifferentHash()
+        {
+            var recorder = new PromptReplayRecorder();
+            recorder.StartRecording("c1");
+            recorder.Record(MakeInteraction(prompt: "test1", model: "gpt-4"));
+            recorder.Record(MakeInteraction(prompt: "test2", model: "gpt-4"));
+            var cassette = recorder.StopRecording();
+
+            Assert.NotEqual(cassette.Interactions[0].Fingerprint,
+                            cassette.Interactions[1].Fingerprint);
+        }
+
+        // ── Cassette model ──────────────────────────────────────
+
+        [Fact]
+        public void Cassette_DefaultVersion_Is1()
+        {
+            var c = new Cassette();
+            Assert.Equal(1, c.Version);
+            Assert.Empty(c.Interactions);
+            Assert.Empty(c.Tags);
+        }
+
+        // ── ReplayResult model ──────────────────────────────────
+
+        [Fact]
+        public void ReplayResult_IsHit_FalseWhenNull()
+        {
+            var r = new ReplayResult();
+            Assert.False(r.IsHit);
+            Assert.Null(r.Recording);
+        }
+
+        // ── ReplayStats ─────────────────────────────────────────
+
+        [Fact]
+        public void ReplayStats_HitRate_ZeroWhenNoAttempts()
+        {
+            var s = new ReplayStats();
+            Assert.Equal(0, s.HitRate);
+        }
+    }
+}


### PR DESCRIPTION
Records LLM prompt interactions into named cassettes, then replays them without hitting the API.

**Features:**
- 3 replay strategies: Exact (fingerprint), PromptOnly (ignore model), Sequential
- Cassette management: list, get, remove, clear, tag, findByTag
- JSON export/import, cassette comparison (diff for regressions)
- Summary analytics, replay stats (hit rate, cost saved)
- Thread-safe, SHA256 content fingerprinting

+742 source, +730 test (56 xUnit tests, all passing).