### PR TITLE
feat: PromptAnnotation — structured inline comments and metadata for prompts

### DIFF
--- a/src/PromptAnnotation.cs
+++ b/src/PromptAnnotation.cs
@@ -1,0 +1,465 @@
+namespace Prompt
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+
+    /// <summary>
+    /// Classification of a prompt annotation.
+    /// </summary>
+    public enum AnnotationType
+    {
+        /// <summary>Free-form comment — stripped before API calls.</summary>
+        Comment,
+
+        /// <summary>Structured metadata tag (key-value pair).</summary>
+        Metadata,
+
+        /// <summary>Section boundary marker for logical grouping.</summary>
+        Section,
+
+        /// <summary>Directive that controls processing behavior.</summary>
+        Directive
+    }
+
+    /// <summary>
+    /// Represents a single annotation found within a prompt.
+    /// </summary>
+    public sealed record PromptAnnotationEntry
+    {
+        /// <summary>The annotation type.</summary>
+        public AnnotationType Type { get; init; }
+
+        /// <summary>The raw annotation text including delimiters.</summary>
+        public string RawText { get; init; } = "";
+
+        /// <summary>The annotation content after delimiter stripping.</summary>
+        public string Content { get; init; } = "";
+
+        /// <summary>Metadata key (for <see cref="AnnotationType.Metadata"/> entries).</summary>
+        public string? Key { get; init; }
+
+        /// <summary>Metadata value (for <see cref="AnnotationType.Metadata"/> entries).</summary>
+        public string? Value { get; init; }
+
+        /// <summary>Zero-based character offset where this annotation starts in the original text.</summary>
+        public int StartIndex { get; init; }
+
+        /// <summary>Zero-based character offset where this annotation ends (exclusive).</summary>
+        public int EndIndex { get; init; }
+
+        /// <summary>The 1-based line number where the annotation begins.</summary>
+        public int Line { get; init; }
+    }
+
+    /// <summary>
+    /// Result of extracting all annotations from a prompt.
+    /// </summary>
+    public sealed class AnnotationResult
+    {
+        /// <summary>The original prompt text.</summary>
+        public string OriginalText { get; init; } = "";
+
+        /// <summary>The prompt text with all annotations removed.</summary>
+        public string StrippedText { get; init; } = "";
+
+        /// <summary>All annotations found, in order of appearance.</summary>
+        public IReadOnlyList<PromptAnnotationEntry> Annotations { get; init; }
+            = Array.Empty<PromptAnnotationEntry>();
+
+        /// <summary>
+        /// Metadata key-value pairs extracted from <c>@key: value</c> annotations.
+        /// Keys are case-insensitive. If a key appears multiple times, values are comma-joined.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> Metadata { get; init; }
+            = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>All tags collected from <c>@tag: ...</c> annotations.</summary>
+        public IReadOnlyList<string> Tags { get; init; } = Array.Empty<string>();
+
+        /// <summary>Section names found in <c>@section: name</c> annotations.</summary>
+        public IReadOnlyList<string> Sections { get; init; } = Array.Empty<string>();
+
+        /// <summary>Validation warnings (e.g., unclosed annotations, unknown directives).</summary>
+        public IReadOnlyList<string> Warnings { get; init; } = Array.Empty<string>();
+
+        /// <summary>True if the prompt has no annotations.</summary>
+        public bool IsClean => Annotations.Count == 0;
+
+        /// <summary>Number of tokens saved by stripping annotations (approximate).</summary>
+        public int EstimatedTokensSaved { get; init; }
+    }
+
+    /// <summary>
+    /// Structured prompt annotation system.
+    /// <para>
+    /// Embeds inline comments and metadata within prompt text using a
+    /// <c>{{# ... #}}</c> delimiter syntax. Annotations are stripped
+    /// before sending prompts to an LLM, preserving documentation and
+    /// metadata without wasting tokens.
+    /// </para>
+    ///
+    /// <para><b>Annotation syntax:</b></para>
+    /// <list type="bullet">
+    ///   <item><c>{{# This is a comment #}}</c> — free-form comment</item>
+    ///   <item><c>{{# @author: Jane Doe #}}</c> — metadata key-value pair</item>
+    ///   <item><c>{{# @version: 2.1 #}}</c> — version metadata</item>
+    ///   <item><c>{{# @tag: safety, production #}}</c> — tags (comma-separated)</item>
+    ///   <item><c>{{# @section: introduction #}}</c> — section boundary marker</item>
+    ///   <item><c>{{# @freeze #}}</c> — directive (no value)</item>
+    /// </list>
+    ///
+    /// <para><b>Usage:</b></para>
+    /// <code>
+    /// var result = PromptAnnotation.Extract("You are {{# @role: system #}} a helpful assistant.");
+    /// Console.WriteLine(result.StrippedText);    // "You are  a helpful assistant."
+    /// Console.WriteLine(result.Metadata["role"]); // "system"
+    ///
+    /// // Quick strip without metadata extraction:
+    /// string clean = PromptAnnotation.Strip("Hello {{# draft comment #}} world");
+    /// // clean == "Hello  world"
+    /// </code>
+    /// </summary>
+    public static class PromptAnnotation
+    {
+        /// <summary>Opening delimiter for annotations.</summary>
+        public const string OpenDelimiter = "{{#";
+
+        /// <summary>Closing delimiter for annotations.</summary>
+        public const string CloseDelimiter = "#}}";
+
+        // Regex for balanced annotation blocks (non-greedy).
+        private static readonly Regex AnnotationPattern = new(
+            @"\{\{#\s*(.*?)\s*#\}\}",
+            RegexOptions.Singleline | RegexOptions.Compiled);
+
+        // Metadata pattern: @key: value  or  @key (directive, no value).
+        private static readonly Regex MetadataPattern = new(
+            @"^@(\w[\w.-]*)\s*(?::\s*(.*))?$",
+            RegexOptions.Compiled);
+
+        // Known directive keywords (no value expected).
+        private static readonly HashSet<string> KnownDirectives = new(
+            StringComparer.OrdinalIgnoreCase)
+        {
+            "freeze", "lock", "final", "deprecated", "experimental",
+            "required", "optional", "sensitive", "redact", "nolog"
+        };
+
+        // Approximate tokens per character (GPT-family heuristic).
+        private const double TokensPerChar = 0.25;
+
+        /// <summary>
+        /// Remove all annotations from a prompt, returning only the clean text.
+        /// This is the fastest path when metadata is not needed.
+        /// </summary>
+        /// <param name="prompt">The annotated prompt text.</param>
+        /// <returns>The prompt with all <c>{{# ... #}}</c> blocks removed.</returns>
+        public static string Strip(string prompt)
+        {
+            if (string.IsNullOrEmpty(prompt)) return prompt ?? "";
+            if (!prompt.Contains(OpenDelimiter)) return prompt;
+            return AnnotationPattern.Replace(prompt, "");
+        }
+
+        /// <summary>
+        /// Extract all annotations and metadata from a prompt.
+        /// </summary>
+        /// <param name="prompt">The annotated prompt text.</param>
+        /// <returns>An <see cref="AnnotationResult"/> with stripped text, metadata, tags, and warnings.</returns>
+        public static AnnotationResult Extract(string prompt)
+        {
+            if (string.IsNullOrEmpty(prompt))
+            {
+                return new AnnotationResult
+                {
+                    OriginalText = prompt ?? "",
+                    StrippedText = prompt ?? ""
+                };
+            }
+
+            var annotations = new List<PromptAnnotationEntry>();
+            var metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var tags = new List<string>();
+            var sections = new List<string>();
+            var warnings = new List<string>();
+
+            foreach (Match match in AnnotationPattern.Matches(prompt))
+            {
+                var content = match.Groups[1].Value.Trim();
+                var line = CountLines(prompt, match.Index);
+                var entry = new PromptAnnotationEntry
+                {
+                    RawText = match.Value,
+                    Content = content,
+                    StartIndex = match.Index,
+                    EndIndex = match.Index + match.Length,
+                    Line = line
+                };
+
+                var metaMatch = MetadataPattern.Match(content);
+                if (metaMatch.Success)
+                {
+                    var key = metaMatch.Groups[1].Value;
+                    var value = metaMatch.Groups[2].Success
+                        ? metaMatch.Groups[2].Value.Trim()
+                        : null;
+
+                    if (string.IsNullOrEmpty(value) && KnownDirectives.Contains(key))
+                    {
+                        entry = entry with
+                        {
+                            Type = AnnotationType.Directive,
+                            Key = key
+                        };
+                    }
+                    else if (key.Equals("section", StringComparison.OrdinalIgnoreCase))
+                    {
+                        entry = entry with
+                        {
+                            Type = AnnotationType.Section,
+                            Key = key,
+                            Value = value
+                        };
+                        if (!string.IsNullOrEmpty(value))
+                            sections.Add(value);
+                    }
+                    else if (key.Equals("tag", StringComparison.OrdinalIgnoreCase))
+                    {
+                        entry = entry with
+                        {
+                            Type = AnnotationType.Metadata,
+                            Key = key,
+                            Value = value
+                        };
+                        if (!string.IsNullOrEmpty(value))
+                        {
+                            foreach (var t in value.Split(','))
+                            {
+                                var trimmed = t.Trim();
+                                if (trimmed.Length > 0 && !tags.Contains(trimmed))
+                                    tags.Add(trimmed);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        entry = entry with
+                        {
+                            Type = AnnotationType.Metadata,
+                            Key = key,
+                            Value = value
+                        };
+                        if (!string.IsNullOrEmpty(value))
+                        {
+                            if (metadata.TryGetValue(key, out var existing))
+                                metadata[key] = existing + ", " + value;
+                            else
+                                metadata[key] = value;
+                        }
+                    }
+                }
+                else
+                {
+                    entry = entry with { Type = AnnotationType.Comment };
+                }
+
+                annotations.Add(entry);
+            }
+
+            // Check for unclosed annotations
+            var openCount = CountOccurrences(prompt, OpenDelimiter);
+            var closeCount = CountOccurrences(prompt, CloseDelimiter);
+            if (openCount > closeCount)
+                warnings.Add($"Found {openCount - closeCount} unclosed annotation(s) — missing '#}}}}'.");
+            if (closeCount > openCount)
+                warnings.Add($"Found {closeCount - openCount} stray closing delimiter(s) '#}}}}'.");
+
+            var stripped = AnnotationPattern.Replace(prompt, "");
+            var charsSaved = prompt.Length - stripped.Length;
+
+            return new AnnotationResult
+            {
+                OriginalText = prompt,
+                StrippedText = stripped,
+                Annotations = annotations,
+                Metadata = metadata,
+                Tags = tags,
+                Sections = sections,
+                Warnings = warnings,
+                EstimatedTokensSaved = (int)Math.Ceiling(charsSaved * TokensPerChar)
+            };
+        }
+
+        /// <summary>
+        /// Validate annotation syntax without extracting metadata.
+        /// Returns a list of warnings/errors. An empty list means the syntax is valid.
+        /// </summary>
+        public static IReadOnlyList<string> Validate(string prompt)
+        {
+            if (string.IsNullOrEmpty(prompt))
+                return Array.Empty<string>();
+
+            var issues = new List<string>();
+
+            var openCount = CountOccurrences(prompt, OpenDelimiter);
+            var closeCount = CountOccurrences(prompt, CloseDelimiter);
+
+            if (openCount != closeCount)
+            {
+                issues.Add(openCount > closeCount
+                    ? $"Unclosed annotation: {openCount} opening vs {closeCount} closing delimiters."
+                    : $"Stray closing delimiter: {closeCount} closing vs {openCount} opening delimiters.");
+            }
+
+            // Check for nested annotations (not supported)
+            foreach (Match match in AnnotationPattern.Matches(prompt))
+            {
+                var inner = match.Groups[1].Value;
+                if (inner.Contains(OpenDelimiter))
+                {
+                    var line = CountLines(prompt, match.Index);
+                    issues.Add($"Nested annotation detected at line {line} — nesting is not supported.");
+                }
+            }
+
+            // Check for empty annotations
+            foreach (Match match in AnnotationPattern.Matches(prompt))
+            {
+                if (string.IsNullOrWhiteSpace(match.Groups[1].Value))
+                {
+                    var line = CountLines(prompt, match.Index);
+                    issues.Add($"Empty annotation at line {line}.");
+                }
+            }
+
+            return issues;
+        }
+
+        /// <summary>
+        /// Insert an annotation at a specific position in the prompt.
+        /// </summary>
+        /// <param name="prompt">The prompt text.</param>
+        /// <param name="position">Zero-based character index to insert at.</param>
+        /// <param name="content">The annotation content (without delimiters).</param>
+        /// <returns>The prompt with the annotation inserted.</returns>
+        public static string Insert(string prompt, int position, string content)
+        {
+            prompt ??= "";
+            if (position < 0) position = 0;
+            if (position > prompt.Length) position = prompt.Length;
+            var annotation = $"{OpenDelimiter} {content} {CloseDelimiter}";
+            return prompt.Insert(position, annotation);
+        }
+
+        /// <summary>
+        /// Add a metadata annotation at the beginning of the prompt.
+        /// </summary>
+        /// <param name="prompt">The prompt text.</param>
+        /// <param name="key">The metadata key.</param>
+        /// <param name="value">The metadata value.</param>
+        /// <returns>The prompt with the metadata annotation prepended.</returns>
+        public static string AddMetadata(string prompt, string key, string value)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentException("Metadata key cannot be empty.", nameof(key));
+            var annotation = $"{OpenDelimiter} @{key}: {value} {CloseDelimiter}\n";
+            return annotation + (prompt ?? "");
+        }
+
+        /// <summary>
+        /// Add a tag annotation at the beginning of the prompt.
+        /// </summary>
+        public static string AddTag(string prompt, params string[] tagValues)
+        {
+            if (tagValues == null || tagValues.Length == 0) return prompt ?? "";
+            var joined = string.Join(", ", tagValues.Where(t => !string.IsNullOrWhiteSpace(t)));
+            if (joined.Length == 0) return prompt ?? "";
+            return $"{OpenDelimiter} @tag: {joined} {CloseDelimiter}\n" + (prompt ?? "");
+        }
+
+        /// <summary>
+        /// Add a section marker at a specific position.
+        /// </summary>
+        public static string AddSection(string prompt, int position, string sectionName)
+        {
+            if (string.IsNullOrWhiteSpace(sectionName))
+                throw new ArgumentException("Section name cannot be empty.", nameof(sectionName));
+            return Insert(prompt ?? "", position, $"@section: {sectionName}");
+        }
+
+        /// <summary>
+        /// Get only the annotations of a specific type.
+        /// </summary>
+        public static IReadOnlyList<PromptAnnotationEntry> GetByType(
+            string prompt, AnnotationType type)
+        {
+            return Extract(prompt).Annotations
+                .Where(a => a.Type == type)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Check whether a prompt contains any annotations.
+        /// </summary>
+        public static bool HasAnnotations(string prompt)
+        {
+            if (string.IsNullOrEmpty(prompt)) return false;
+            return prompt.Contains(OpenDelimiter) && prompt.Contains(CloseDelimiter)
+                && AnnotationPattern.IsMatch(prompt);
+        }
+
+        /// <summary>
+        /// Get a summary string describing the annotations found.
+        /// </summary>
+        public static string Summarize(string prompt)
+        {
+            var result = Extract(prompt);
+            if (result.IsClean)
+                return "No annotations found.";
+
+            var parts = new List<string>
+            {
+                $"{result.Annotations.Count} annotation(s)"
+            };
+
+            var comments = result.Annotations.Count(a => a.Type == AnnotationType.Comment);
+            var metas = result.Annotations.Count(a => a.Type == AnnotationType.Metadata);
+            var sections = result.Annotations.Count(a => a.Type == AnnotationType.Section);
+            var directives = result.Annotations.Count(a => a.Type == AnnotationType.Directive);
+
+            if (comments > 0) parts.Add($"{comments} comment(s)");
+            if (metas > 0) parts.Add($"{metas} metadata");
+            if (sections > 0) parts.Add($"{sections} section(s)");
+            if (directives > 0) parts.Add($"{directives} directive(s)");
+            parts.Add($"~{result.EstimatedTokensSaved} tokens saved");
+
+            return string.Join(", ", parts);
+        }
+
+        // ── Helpers ──────────────────────────────────────────────
+
+        private static int CountLines(string text, int upToIndex)
+        {
+            int line = 1;
+            for (int i = 0; i < upToIndex && i < text.Length; i++)
+            {
+                if (text[i] == '\n') line++;
+            }
+            return line;
+        }
+
+        private static int CountOccurrences(string text, string pattern)
+        {
+            int count = 0;
+            int idx = 0;
+            while ((idx = text.IndexOf(pattern, idx, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                idx += pattern.Length;
+            }
+            return count;
+        }
+    }
+}

--- a/tests/PromptAnnotationTests.cs
+++ b/tests/PromptAnnotationTests.cs
@@ -1,0 +1,536 @@
+namespace Prompt.Tests;
+
+using System;
+using System.Linq;
+using Xunit;
+
+/// <summary>
+/// Tests for <see cref="PromptAnnotation"/> — structured prompt
+/// annotation system with inline comments, metadata extraction,
+/// tag parsing, section markers, directives, and validation.
+/// </summary>
+public class PromptAnnotationTests
+{
+    // ── Strip ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Strip_RemovesSingleComment()
+    {
+        var result = PromptAnnotation.Strip("Hello {{# comment #}} world");
+        Assert.Equal("Hello  world", result);
+    }
+
+    [Fact]
+    public void Strip_RemovesMultipleAnnotations()
+    {
+        var result = PromptAnnotation.Strip(
+            "{{# @author: Jane #}}Start {{# note #}} end{{# @version: 1.0 #}}");
+        Assert.Equal("Start  end", result);
+    }
+
+    [Fact]
+    public void Strip_NoAnnotations_ReturnsOriginal()
+    {
+        Assert.Equal("Hello world", PromptAnnotation.Strip("Hello world"));
+    }
+
+    [Fact]
+    public void Strip_EmptyString_ReturnsEmpty()
+    {
+        Assert.Equal("", PromptAnnotation.Strip(""));
+    }
+
+    [Fact]
+    public void Strip_Null_ReturnsEmpty()
+    {
+        Assert.Equal("", PromptAnnotation.Strip(null!));
+    }
+
+    [Fact]
+    public void Strip_MultilineAnnotation()
+    {
+        var prompt = "Start {{# this\nis a\nmultiline comment #}} end";
+        Assert.Equal("Start  end", PromptAnnotation.Strip(prompt));
+    }
+
+    // ── Extract: Comments ────────────────────────────────────
+
+    [Fact]
+    public void Extract_Comment_ParsedCorrectly()
+    {
+        var result = PromptAnnotation.Extract("Test {{# a comment #}} here");
+        Assert.Single(result.Annotations);
+        Assert.Equal(AnnotationType.Comment, result.Annotations[0].Type);
+        Assert.Equal("a comment", result.Annotations[0].Content);
+    }
+
+    [Fact]
+    public void Extract_Comment_PositionTracked()
+    {
+        var result = PromptAnnotation.Extract("ABC {{# note #}} DEF");
+        var ann = result.Annotations[0];
+        Assert.Equal(4, ann.StartIndex);
+        Assert.Equal(16, ann.EndIndex);
+        Assert.Equal(1, ann.Line);
+    }
+
+    [Fact]
+    public void Extract_Comment_LineNumberTracked()
+    {
+        var result = PromptAnnotation.Extract("Line 1\nLine 2 {{# note #}} rest");
+        Assert.Equal(2, result.Annotations[0].Line);
+    }
+
+    [Fact]
+    public void Extract_MultipleComments()
+    {
+        var result = PromptAnnotation.Extract(
+            "{{# first #}} mid {{# second #}} end");
+        Assert.Equal(2, result.Annotations.Count);
+        Assert.Equal("first", result.Annotations[0].Content);
+        Assert.Equal("second", result.Annotations[1].Content);
+    }
+
+    // ── Extract: Metadata ────────────────────────────────────
+
+    [Fact]
+    public void Extract_Metadata_KeyValue()
+    {
+        var result = PromptAnnotation.Extract("{{# @author: Jane Doe #}} prompt");
+        Assert.Single(result.Annotations);
+        Assert.Equal(AnnotationType.Metadata, result.Annotations[0].Type);
+        Assert.Equal("author", result.Annotations[0].Key);
+        Assert.Equal("Jane Doe", result.Annotations[0].Value);
+        Assert.Equal("Jane Doe", result.Metadata["author"]);
+    }
+
+    [Fact]
+    public void Extract_Metadata_MultipleKeys()
+    {
+        var prompt = "{{# @author: John #}} {{# @version: 2.0 #}} text";
+        var result = PromptAnnotation.Extract(prompt);
+        Assert.Equal(2, result.Metadata.Count);
+        Assert.Equal("John", result.Metadata["author"]);
+        Assert.Equal("2.0", result.Metadata["version"]);
+    }
+
+    [Fact]
+    public void Extract_Metadata_DuplicateKeysMerged()
+    {
+        var prompt = "{{# @author: Alice #}} {{# @author: Bob #}} text";
+        var result = PromptAnnotation.Extract(prompt);
+        Assert.Equal("Alice, Bob", result.Metadata["author"]);
+    }
+
+    [Fact]
+    public void Extract_Metadata_CaseInsensitiveKeys()
+    {
+        var result = PromptAnnotation.Extract("{{# @Author: Jane #}} text");
+        Assert.True(result.Metadata.ContainsKey("author"));
+        Assert.True(result.Metadata.ContainsKey("AUTHOR"));
+    }
+
+    // ── Extract: Tags ────────────────────────────────────────
+
+    [Fact]
+    public void Extract_Tags_SingleTag()
+    {
+        var result = PromptAnnotation.Extract("{{# @tag: safety #}} prompt");
+        Assert.Single(result.Tags);
+        Assert.Equal("safety", result.Tags[0]);
+    }
+
+    [Fact]
+    public void Extract_Tags_CommaSeparated()
+    {
+        var result = PromptAnnotation.Extract(
+            "{{# @tag: safety, production, v2 #}} prompt");
+        Assert.Equal(3, result.Tags.Count);
+        Assert.Contains("safety", result.Tags);
+        Assert.Contains("production", result.Tags);
+        Assert.Contains("v2", result.Tags);
+    }
+
+    [Fact]
+    public void Extract_Tags_MultipleTags_NoDuplicates()
+    {
+        var result = PromptAnnotation.Extract(
+            "{{# @tag: safety #}} {{# @tag: safety, new #}} prompt");
+        Assert.Equal(2, result.Tags.Count);
+        Assert.Contains("safety", result.Tags);
+        Assert.Contains("new", result.Tags);
+    }
+
+    // ── Extract: Sections ────────────────────────────────────
+
+    [Fact]
+    public void Extract_Section_Tracked()
+    {
+        var result = PromptAnnotation.Extract(
+            "{{# @section: intro #}} Welcome {{# @section: body #}} Main text");
+        Assert.Equal(2, result.Sections.Count);
+        Assert.Equal("intro", result.Sections[0]);
+        Assert.Equal("body", result.Sections[1]);
+        Assert.Equal(AnnotationType.Section, result.Annotations[0].Type);
+    }
+
+    // ── Extract: Directives ──────────────────────────────────
+
+    [Fact]
+    public void Extract_Directive_NoValue()
+    {
+        var result = PromptAnnotation.Extract("{{# @freeze #}} important prompt");
+        Assert.Single(result.Annotations);
+        Assert.Equal(AnnotationType.Directive, result.Annotations[0].Type);
+        Assert.Equal("freeze", result.Annotations[0].Key);
+        Assert.Null(result.Annotations[0].Value);
+    }
+
+    [Fact]
+    public void Extract_Directive_AllKnownDirectives()
+    {
+        var directives = new[] { "freeze", "lock", "final", "deprecated",
+            "experimental", "required", "optional", "sensitive", "redact", "nolog" };
+        foreach (var d in directives)
+        {
+            var result = PromptAnnotation.Extract($"{{{{# @{d} #}}}} text");
+            Assert.Equal(AnnotationType.Directive, result.Annotations[0].Type);
+        }
+    }
+
+    // ── Extract: Stripped Text ────────────────────────────────
+
+    [Fact]
+    public void Extract_StrippedText_AnnotationsRemoved()
+    {
+        var result = PromptAnnotation.Extract(
+            "You are {{# @role: system #}} a helpful {{# doc note #}} assistant.");
+        Assert.Equal("You are  a helpful  assistant.", result.StrippedText);
+    }
+
+    [Fact]
+    public void Extract_OriginalTextPreserved()
+    {
+        var prompt = "Hello {{# test #}} world";
+        var result = PromptAnnotation.Extract(prompt);
+        Assert.Equal(prompt, result.OriginalText);
+    }
+
+    [Fact]
+    public void Extract_IsClean_NoAnnotations()
+    {
+        var result = PromptAnnotation.Extract("No annotations here");
+        Assert.True(result.IsClean);
+    }
+
+    [Fact]
+    public void Extract_IsClean_WithAnnotations()
+    {
+        var result = PromptAnnotation.Extract("Has {{# one #}} annotation");
+        Assert.False(result.IsClean);
+    }
+
+    [Fact]
+    public void Extract_EstimatedTokensSaved()
+    {
+        var result = PromptAnnotation.Extract(
+            "text {{# this is a comment that saves tokens #}} more text");
+        Assert.True(result.EstimatedTokensSaved > 0);
+    }
+
+    // ── Validate ─────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_ValidSyntax_NoIssues()
+    {
+        var issues = PromptAnnotation.Validate("Hello {{# comment #}} world");
+        Assert.Empty(issues);
+    }
+
+    [Fact]
+    public void Validate_UnclosedAnnotation()
+    {
+        var issues = PromptAnnotation.Validate("Hello {{# unclosed annotation");
+        Assert.Single(issues);
+        Assert.Contains("Unclosed", issues[0]);
+    }
+
+    [Fact]
+    public void Validate_StrayClosingDelimiter()
+    {
+        var issues = PromptAnnotation.Validate("Hello world #}}");
+        Assert.Single(issues);
+        Assert.Contains("Stray", issues[0]);
+    }
+
+    [Fact]
+    public void Validate_EmptyAnnotation()
+    {
+        var issues = PromptAnnotation.Validate("Hello {{#  #}} world");
+        Assert.Single(issues);
+        Assert.Contains("Empty", issues[0]);
+    }
+
+    [Fact]
+    public void Validate_EmptyString_NoIssues()
+    {
+        Assert.Empty(PromptAnnotation.Validate(""));
+    }
+
+    [Fact]
+    public void Validate_NullString_NoIssues()
+    {
+        Assert.Empty(PromptAnnotation.Validate(null!));
+    }
+
+    [Fact]
+    public void Validate_NoAnnotations_NoIssues()
+    {
+        Assert.Empty(PromptAnnotation.Validate("Clean text with no annotations"));
+    }
+
+    // ── Insert ───────────────────────────────────────────────
+
+    [Fact]
+    public void Insert_AtBeginning()
+    {
+        var result = PromptAnnotation.Insert("Hello", 0, "note");
+        Assert.StartsWith("{{# note #}}", result);
+        Assert.EndsWith("Hello", result);
+    }
+
+    [Fact]
+    public void Insert_AtEnd()
+    {
+        var result = PromptAnnotation.Insert("Hello", 5, "note");
+        Assert.StartsWith("Hello", result);
+        Assert.EndsWith("{{# note #}}", result);
+    }
+
+    [Fact]
+    public void Insert_InMiddle()
+    {
+        var result = PromptAnnotation.Insert("HelloWorld", 5, "note");
+        Assert.Equal("Hello{{# note #}}World", result);
+    }
+
+    [Fact]
+    public void Insert_NegativePosition_ClampsToZero()
+    {
+        var result = PromptAnnotation.Insert("Hello", -5, "note");
+        Assert.StartsWith("{{# note #}}", result);
+    }
+
+    [Fact]
+    public void Insert_PastEnd_ClampsToEnd()
+    {
+        var result = PromptAnnotation.Insert("Hi", 100, "note");
+        Assert.EndsWith("{{# note #}}", result);
+    }
+
+    // ── AddMetadata ──────────────────────────────────────────
+
+    [Fact]
+    public void AddMetadata_PrependsAnnotation()
+    {
+        var result = PromptAnnotation.AddMetadata("Hello", "author", "Jane");
+        Assert.StartsWith("{{# @author: Jane #}}", result);
+        Assert.EndsWith("Hello", result);
+    }
+
+    [Fact]
+    public void AddMetadata_EmptyKey_Throws()
+    {
+        Assert.Throws<ArgumentException>(
+            () => PromptAnnotation.AddMetadata("text", "", "value"));
+    }
+
+    [Fact]
+    public void AddMetadata_Extractable()
+    {
+        var prompt = PromptAnnotation.AddMetadata("Hello", "version", "3.0");
+        var result = PromptAnnotation.Extract(prompt);
+        Assert.Equal("3.0", result.Metadata["version"]);
+    }
+
+    // ── AddTag ───────────────────────────────────────────────
+
+    [Fact]
+    public void AddTag_PrependsTagAnnotation()
+    {
+        var result = PromptAnnotation.AddTag("Hello", "safety", "prod");
+        Assert.StartsWith("{{# @tag: safety, prod #}}", result);
+    }
+
+    [Fact]
+    public void AddTag_Extractable()
+    {
+        var prompt = PromptAnnotation.AddTag("Hello", "safety", "v2");
+        var result = PromptAnnotation.Extract(prompt);
+        Assert.Contains("safety", result.Tags);
+        Assert.Contains("v2", result.Tags);
+    }
+
+    [Fact]
+    public void AddTag_EmptyArray_ReturnsOriginal()
+    {
+        Assert.Equal("Hello", PromptAnnotation.AddTag("Hello"));
+    }
+
+    [Fact]
+    public void AddTag_NullPrompt_ReturnsAnnotation()
+    {
+        var result = PromptAnnotation.AddTag(null!, "tag1");
+        Assert.Contains("tag1", result);
+    }
+
+    // ── AddSection ───────────────────────────────────────────
+
+    [Fact]
+    public void AddSection_InsertsMarker()
+    {
+        var result = PromptAnnotation.AddSection("HelloWorld", 5, "intro");
+        Assert.Contains("@section: intro", result);
+        Assert.StartsWith("Hello", result);
+    }
+
+    [Fact]
+    public void AddSection_EmptyName_Throws()
+    {
+        Assert.Throws<ArgumentException>(
+            () => PromptAnnotation.AddSection("text", 0, ""));
+    }
+
+    // ── GetByType ────────────────────────────────────────────
+
+    [Fact]
+    public void GetByType_FiltersCorrectly()
+    {
+        var prompt = "{{# comment #}} {{# @author: X #}} {{# @freeze #}} text";
+        var comments = PromptAnnotation.GetByType(prompt, AnnotationType.Comment);
+        Assert.Single(comments);
+        var metas = PromptAnnotation.GetByType(prompt, AnnotationType.Metadata);
+        Assert.Single(metas);
+        var dirs = PromptAnnotation.GetByType(prompt, AnnotationType.Directive);
+        Assert.Single(dirs);
+    }
+
+    // ── HasAnnotations ───────────────────────────────────────
+
+    [Fact]
+    public void HasAnnotations_True()
+    {
+        Assert.True(PromptAnnotation.HasAnnotations("{{# note #}} text"));
+    }
+
+    [Fact]
+    public void HasAnnotations_False()
+    {
+        Assert.False(PromptAnnotation.HasAnnotations("No annotations"));
+    }
+
+    [Fact]
+    public void HasAnnotations_Empty()
+    {
+        Assert.False(PromptAnnotation.HasAnnotations(""));
+    }
+
+    [Fact]
+    public void HasAnnotations_PartialDelimiter_False()
+    {
+        Assert.False(PromptAnnotation.HasAnnotations("{{# unclosed"));
+    }
+
+    // ── Summarize ────────────────────────────────────────────
+
+    [Fact]
+    public void Summarize_NoAnnotations()
+    {
+        Assert.Equal("No annotations found.", PromptAnnotation.Summarize("clean text"));
+    }
+
+    [Fact]
+    public void Summarize_WithAnnotations()
+    {
+        var prompt = "{{# comment #}} {{# @author: X #}} {{# @freeze #}} text";
+        var summary = PromptAnnotation.Summarize(prompt);
+        Assert.Contains("3 annotation(s)", summary);
+        Assert.Contains("1 comment(s)", summary);
+        Assert.Contains("1 metadata", summary);
+        Assert.Contains("1 directive(s)", summary);
+        Assert.Contains("tokens saved", summary);
+    }
+
+    // ── Warnings ─────────────────────────────────────────────
+
+    [Fact]
+    public void Extract_UnclosedAnnotation_Warning()
+    {
+        var result = PromptAnnotation.Extract("text {{# unclosed");
+        Assert.NotEmpty(result.Warnings);
+        Assert.Contains("unclosed", result.Warnings[0], StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Extract_BalancedAnnotation_NoWarnings()
+    {
+        var result = PromptAnnotation.Extract("text {{# balanced #}} end");
+        Assert.Empty(result.Warnings);
+    }
+
+    // ── Round-trip ───────────────────────────────────────────
+
+    [Fact]
+    public void RoundTrip_StripThenHasAnnotations_False()
+    {
+        var annotated = "{{# @author: Jane #}} {{# comment #}} Do the thing.";
+        var stripped = PromptAnnotation.Strip(annotated);
+        Assert.False(PromptAnnotation.HasAnnotations(stripped));
+    }
+
+    [Fact]
+    public void RoundTrip_AddMetadataThenExtract()
+    {
+        var prompt = "Hello world";
+        prompt = PromptAnnotation.AddMetadata(prompt, "version", "1.0");
+        prompt = PromptAnnotation.AddMetadata(prompt, "author", "Test");
+        prompt = PromptAnnotation.AddTag(prompt, "prod", "v1");
+        var result = PromptAnnotation.Extract(prompt);
+        Assert.Equal("1.0", result.Metadata["version"]);
+        Assert.Equal("Test", result.Metadata["author"]);
+        Assert.Contains("prod", result.Tags);
+        Assert.Contains("v1", result.Tags);
+        Assert.False(PromptAnnotation.HasAnnotations(result.StrippedText));
+    }
+
+    // ── Edge Cases ───────────────────────────────────────────
+
+    [Fact]
+    public void Extract_OnlyAnnotations_StrippedTextEmpty()
+    {
+        var result = PromptAnnotation.Extract("{{# only #}}{{# annotations #}}");
+        Assert.Equal("", result.StrippedText);
+    }
+
+    [Fact]
+    public void Extract_WhitespaceInAnnotation_Trimmed()
+    {
+        var result = PromptAnnotation.Extract("{{#    spaced content    #}}");
+        Assert.Equal("spaced content", result.Annotations[0].Content);
+    }
+
+    [Fact]
+    public void Extract_SpecialCharsInComment()
+    {
+        var result = PromptAnnotation.Extract(
+            "{{# contains <html> & \"quotes\" #}} text");
+        Assert.Equal("contains <html> & \"quotes\"", result.Annotations[0].Content);
+    }
+
+    [Fact]
+    public void Extract_MetadataKeyWithDots()
+    {
+        var result = PromptAnnotation.Extract("{{# @api.version: 3.1 #}} text");
+        Assert.Equal("3.1", result.Metadata["api.version"]);
+    }
+}


### PR DESCRIPTION
Annotation system using {{# ... #}} delimiters for embedding documentation and metadata in prompts. Stripped before API calls to save tokens.

**10 methods:** Strip, Extract, Validate, Insert, AddMetadata, AddTag, AddSection, GetByType, HasAnnotations, Summarize

**4 annotation types:** Comment, Metadata (@key: value), Tag (@tag: x, y), Section (@section: name), Directive (@freeze, @lock, etc.)

**Key features:** case-insensitive keys, duplicate merging, tag deduplication, section tracking, 10 built-in directives, syntax validation (unclosed/nested/empty), estimated token savings, position + line tracking.

**61 tests** covering all features, edge cases, round-trips, and validation.