### PR TITLE
refactor: remove 5 redundant EstimateTokens wrappers, use PromptGuard directly

### DIFF
--- a/src/PromptABTester.cs
+++ b/src/PromptABTester.cs
@@ -337,8 +337,8 @@ namespace Prompt
                     RenderedPrompt = rendered,
                     Response = simulatedResponse,
                     Elapsed = simulatedElapsed ?? TimeSpan.Zero,
-                    InputTokens = EstimateTokens(rendered),
-                    OutputTokens = EstimateTokens(simulatedResponse),
+                    InputTokens = PromptGuard.EstimateTokens(rendered),
+                    OutputTokens = PromptGuard.EstimateTokens(simulatedResponse),
                     Variables = variables != null ? new Dictionary<string, string>(variables) : null,
                     Success = true,
                     Timestamp = DateTimeOffset.UtcNow
@@ -389,8 +389,8 @@ namespace Prompt
                 result.Response = await modelCall(rendered).ConfigureAwait(false);
                 sw.Stop();
                 result.Elapsed = sw.Elapsed;
-                result.InputTokens = EstimateTokens(rendered);
-                result.OutputTokens = EstimateTokens(result.Response ?? "");
+                result.InputTokens = PromptGuard.EstimateTokens(rendered);
+                result.OutputTokens = PromptGuard.EstimateTokens(result.Response ?? "");
                 result.Success = true;
             }
             catch (Exception ex)
@@ -726,9 +726,6 @@ namespace Prompt
                 throw new InvalidOperationException(
                     $"Maximum of {MaxTrialsPerVariant} trials per variant reached.");
         }
-
-        private static int EstimateTokens(string text) =>
-            PromptGuard.EstimateTokens(text);
 
         private static VariantStats ComputeStats(string name, List<TrialResult> trials)
         {

--- a/src/PromptContextCompressor.cs
+++ b/src/PromptContextCompressor.cs
@@ -270,7 +270,7 @@ namespace Prompt
         public bool FitsInBudget(List<(string Role, string Content)> messages)
         {
             if (messages == null) return true;
-            int total = messages.Sum(m => EstimateTokens(m.Content));
+            int total = messages.Sum(m => PromptGuard.EstimateTokens(m.Content));
             return total <= _options.TargetTokens;
         }
 
@@ -457,8 +457,8 @@ namespace Prompt
                 current = importResult.Messages;
             }
 
-            int originalTokens = messages.Sum(m => EstimateTokens(m.Content));
-            int compressedTokens = current.Sum(m => EstimateTokens(m.Content));
+            int originalTokens = messages.Sum(m => PromptGuard.EstimateTokens(m.Content));
+            int compressedTokens = current.Sum(m => PromptGuard.EstimateTokens(m.Content));
 
             return new CompressionResult
             {
@@ -478,7 +478,7 @@ namespace Prompt
         private ScoredMessage ScoreMessage(string role, string content, int index, int totalCount)
         {
             double recency = totalCount > 1 ? (double)index / (totalCount - 1) : 1.0;
-            double length = Math.Min(1.0, EstimateTokens(content) / 500.0);
+            double length = Math.Min(1.0, PromptGuard.EstimateTokens(content) / 500.0);
             double roleScore = role.ToLowerInvariant() switch
             {
                 "system" => 1.0,
@@ -519,7 +519,7 @@ namespace Prompt
                 Role = role,
                 Content = content,
                 ImportanceScore = Math.Round(score, 3),
-                EstimatedTokens = EstimateTokens(content)
+                EstimatedTokens = PromptGuard.EstimateTokens(content)
             };
         }
 
@@ -607,12 +607,9 @@ namespace Prompt
 
         // --- Helpers ---
 
-        private static int EstimateTokens(string text) =>
-            PromptGuard.EstimateTokens(text);
-
         private bool FitsInBudgetInternal(List<(string Role, string Content)> messages)
         {
-            return messages.Sum(m => EstimateTokens(m.Content)) <= _options.TargetTokens;
+            return messages.Sum(m => PromptGuard.EstimateTokens(m.Content)) <= _options.TargetTokens;
         }
 
         private CompressionResult BuildResult(
@@ -626,7 +623,7 @@ namespace Prompt
                 .Where((m, i) => keepIndices.Contains(i))
                 .ToList();
 
-            int compressedTokens = compressed.Sum(m => EstimateTokens(m.Content));
+            int compressedTokens = compressed.Sum(m => PromptGuard.EstimateTokens(m.Content));
 
             return new CompressionResult
             {
@@ -678,7 +675,7 @@ namespace Prompt
                 compressed.Add(("system", placeholder));
             }
 
-            int compressedTokens = compressed.Sum(m => EstimateTokens(m.Content));
+            int compressedTokens = compressed.Sum(m => PromptGuard.EstimateTokens(m.Content));
 
             return new CompressionResult
             {

--- a/src/PromptHistory.cs
+++ b/src/PromptHistory.cs
@@ -94,8 +94,8 @@ namespace Prompt
                 Tags = tags != null ? new List<string>(tags) : null,
                 Error = error,
                 Success = error == null && response != null,
-                EstimatedPromptTokens = EstimateTokens(prompt),
-                EstimatedResponseTokens = response != null ? EstimateTokens(response) : 0,
+                EstimatedPromptTokens = PromptGuard.EstimateTokens(prompt),
+                EstimatedResponseTokens = response != null ? PromptGuard.EstimateTokens(response) : 0,
                 Temperature = options?.Temperature,
                 MaxTokens = options?.MaxTokens
             };
@@ -388,8 +388,6 @@ namespace Prompt
         /// <summary>
         /// Rough token estimate (~4 chars per token for English text).
         /// </summary>
-        internal static int EstimateTokens(string text) =>
-            PromptGuard.EstimateTokens(text);
 
         private static double Median(double[] sorted)
         {

--- a/src/PromptMetadataExtractor.cs
+++ b/src/PromptMetadataExtractor.cs
@@ -258,7 +258,7 @@ namespace Prompt
             if (text.Length == 0) return meta;
 
             meta.WordCount = text.Split(new[] { ' ', '\t', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries).Length;
-            meta.EstimatedTokens = EstimateTokens(text);
+            meta.EstimatedTokens = PromptGuard.EstimateTokens(text);
             meta.Language = DetectLanguage(text);
             meta.QuestionCount = CountMatches(QuestionRx, text);
             meta.InstructionCount = CountMatches(InstructionRx, text);
@@ -281,9 +281,6 @@ namespace Prompt
         }
 
         // ── Internals ────────────────────────────────────────────────
-
-        private static int EstimateTokens(string text) =>
-            PromptGuard.EstimateTokens(text);
 
         private static DetectedLanguage DetectLanguage(string text)
         {

--- a/src/PromptTokenOptimizer.cs
+++ b/src/PromptTokenOptimizer.cs
@@ -274,7 +274,7 @@ namespace Prompt
                 };
             }
 
-            var totalTokens = EstimateTokens(prompt);
+            var totalTokens = PromptGuard.EstimateTokens(prompt);
             var sections = IdentifySections(prompt, totalTokens);
             var instructions = ExtractInstructions(prompt);
             var redundancies = DetectRedundancies(instructions);
@@ -318,7 +318,7 @@ namespace Prompt
             var optimizedPrompt = _config.AutoApply
                 ? ApplyOptimizations(prompt, recommendations)
                 : prompt;
-            var optimizedTokens = EstimateTokens(optimizedPrompt);
+            var optimizedTokens = PromptGuard.EstimateTokens(optimizedPrompt);
 
             var score = CalculateOptimizationScore(totalTokens, recommendations);
 
@@ -358,7 +358,7 @@ namespace Prompt
         /// </summary>
         public BudgetCheck CheckBudget(string prompt, int tokenLimit, double reserveRatio = 0.2)
         {
-            var tokens = EstimateTokens(prompt);
+            var tokens = PromptGuard.EstimateTokens(prompt);
             var reserveTokens = (int)(tokenLimit * reserveRatio);
             var availableForPrompt = tokenLimit - reserveTokens;
 
@@ -382,7 +382,7 @@ namespace Prompt
             if (string.IsNullOrEmpty(prompt) || maxTokensPerChunk <= 0)
                 return new[] { prompt ?? "" };
 
-            var totalTokens = EstimateTokens(prompt);
+            var totalTokens = PromptGuard.EstimateTokens(prompt);
             if (totalTokens <= maxTokensPerChunk)
                 return new[] { prompt };
 
@@ -414,7 +414,7 @@ namespace Prompt
                     var sentenceTokens = 0;
                     foreach (var s in sentences)
                     {
-                        var st = EstimateTokens(s);
+                        var st = PromptGuard.EstimateTokens(s);
                         if (sentenceTokens + st > maxTokensPerChunk && sentenceChunk.Count > 0)
                         {
                             chunks.Add(string.Join(" ", sentenceChunk));
@@ -445,9 +445,6 @@ namespace Prompt
 
         // --- Internal methods ---
 
-        internal static int EstimateTokens(string text) =>
-            PromptGuard.EstimateTokens(text);
-
         internal List<PromptSection> IdentifySections(string prompt, int totalTokens)
         {
             var sections = new List<PromptSection>();
@@ -467,7 +464,7 @@ namespace Prompt
                     }
 
                     var name = ExtractSectionName(trimmed);
-                    var tokens = EstimateTokens(trimmed);
+                    var tokens = PromptGuard.EstimateTokens(trimmed);
 
                     sections.Add(new PromptSection
                     {
@@ -566,7 +563,7 @@ namespace Prompt
                     {
                         var shorter = instructions[i].Length <= instructions[j].Length
                             ? instructions[i] : instructions[j];
-                        var longerTokens = EstimateTokens(
+                        var longerTokens = PromptGuard.EstimateTokens(
                             instructions[i].Length > instructions[j].Length
                                 ? instructions[i] : instructions[j]);
 
@@ -620,7 +617,7 @@ namespace Prompt
                 var matches = pattern.Matches(prompt);
                 if (matches.Count > 0)
                 {
-                    var totalSaved = matches.Sum(m => EstimateTokens(m.Value) - EstimateTokens(replacement));
+                    var totalSaved = matches.Sum(m => PromptGuard.EstimateTokens(m.Value) - PromptGuard.EstimateTokens(replacement));
                     if (totalSaved > 0)
                     {
                         recs.Add(new OptimizationRecommendation
@@ -650,11 +647,11 @@ namespace Prompt
 
                 // Check for high word-to-instruction ratio
                 var sentences = Regex.Split(section.Content, @"(?<=[.!?])\s+", RegexOptions.None, TimeSpan.FromMilliseconds(500));
-                var longSentences = sentences.Where(s => EstimateTokens(s) > 30).ToList();
+                var longSentences = sentences.Where(s => PromptGuard.EstimateTokens(s) > 30).ToList();
 
                 if (longSentences.Count > 0)
                 {
-                    var savings = longSentences.Sum(s => EstimateTokens(s) / 4); // estimate 25% reduction
+                    var savings = longSentences.Sum(s => PromptGuard.EstimateTokens(s) / 4); // estimate 25% reduction
                     recs.Add(new OptimizationRecommendation
                     {
                         Category = OptimizationCategory.Verbosity,
@@ -690,7 +687,7 @@ namespace Prompt
                     Description = $"Format instructions repeated {formatMentions.Count} times — consolidate into one directive",
                     OriginalText = string.Join("; ", formatMentions.Take(3)),
                     SuggestedText = formatMentions[0], // keep first
-                    EstimatedTokensSaved = (formatMentions.Count - 1) * EstimateTokens(formatMentions[0]),
+                    EstimatedTokensSaved = (formatMentions.Count - 1) * PromptGuard.EstimateTokens(formatMentions[0]),
                     Confidence = 0.85,
                     Severity = OptimizationSeverity.Medium
                 });
@@ -710,9 +707,9 @@ namespace Prompt
 
             var totalExampleTokens = 0;
             foreach (Match m in exampleMatches)
-                totalExampleTokens += EstimateTokens(m.Value);
+                totalExampleTokens += PromptGuard.EstimateTokens(m.Value);
 
-            var totalTokens = EstimateTokens(prompt);
+            var totalTokens = PromptGuard.EstimateTokens(prompt);
             if (totalExampleTokens > totalTokens * 0.3 && totalExampleTokens > 30)
             {
                 recs.Add(new OptimizationRecommendation

--- a/tests/PromptHistoryTests.cs
+++ b/tests/PromptHistoryTests.cs
@@ -202,9 +202,9 @@ namespace Prompt.Tests
         public void EstimateTokens_ApproximatelyCorrect()
         {
             // ~4 chars per token
-            Assert.Equal(0, PromptHistory.EstimateTokens(""));
-            Assert.Equal(0, PromptHistory.EstimateTokens(null!));
-            Assert.Equal(3, PromptHistory.EstimateTokens("Hello World!")); // 12 chars -> 3 tokens
+            Assert.Equal(0, PromptGuard.EstimateTokens(""));
+            Assert.Equal(0, PromptGuard.EstimateTokens(null!));
+            Assert.Equal(3, PromptGuard.EstimateTokens("Hello World!")); // 12 chars -> 3 tokens
         }
 
         [Fact]

--- a/tests/PromptTokenOptimizerTests.cs
+++ b/tests/PromptTokenOptimizerTests.cs
@@ -12,25 +12,25 @@ namespace Prompt.Tests
         [Fact]
         public void EstimateTokens_EmptyString_ReturnsZero()
         {
-            Assert.Equal(0, PromptTokenOptimizer.EstimateTokens(""));
+            Assert.Equal(0, PromptGuard.EstimateTokens(""));
         }
 
         [Fact]
         public void EstimateTokens_Null_ReturnsZero()
         {
-            Assert.Equal(0, PromptTokenOptimizer.EstimateTokens(null!));
+            Assert.Equal(0, PromptGuard.EstimateTokens(null!));
         }
 
         [Fact]
         public void EstimateTokens_ShortText_ReturnsAtLeastOne()
         {
-            Assert.True(PromptTokenOptimizer.EstimateTokens("Hi") >= 1);
+            Assert.True(PromptGuard.EstimateTokens("Hi") >= 1);
         }
 
         [Fact]
         public void EstimateTokens_LongerText_ReturnsReasonableCount()
         {
-            var tokens = PromptTokenOptimizer.EstimateTokens("The quick brown fox jumps over the lazy dog");
+            var tokens = PromptGuard.EstimateTokens("The quick brown fox jumps over the lazy dog");
             Assert.True(tokens > 5 && tokens < 20);
         }
 
@@ -179,7 +179,7 @@ namespace Prompt.Tests
         public void IdentifySections_MarkdownHeadings_Splits()
         {
             var prompt = "## Part 1\nContent A\n\n## Part 2\nContent B";
-            var totalTokens = PromptTokenOptimizer.EstimateTokens(prompt);
+            var totalTokens = PromptGuard.EstimateTokens(prompt);
             var sections = _optimizer.IdentifySections(prompt, totalTokens);
             Assert.True(sections.Count >= 2);
         }
@@ -188,7 +188,7 @@ namespace Prompt.Tests
         public void IdentifySections_SingleBlock_OneSection()
         {
             var prompt = "Just a simple prompt with no sections.";
-            var totalTokens = PromptTokenOptimizer.EstimateTokens(prompt);
+            var totalTokens = PromptGuard.EstimateTokens(prompt);
             var sections = _optimizer.IdentifySections(prompt, totalTokens);
             Assert.Single(sections);
         }
@@ -197,7 +197,7 @@ namespace Prompt.Tests
         public void IdentifySections_PercentOfTotal_SumsToApprox100()
         {
             var prompt = "## A\nContent\n\n## B\nMore content\n\n## C\nEven more";
-            var totalTokens = PromptTokenOptimizer.EstimateTokens(prompt);
+            var totalTokens = PromptGuard.EstimateTokens(prompt);
             var sections = _optimizer.IdentifySections(prompt, totalTokens);
             var total = sections.Sum(s => s.PercentOfTotal);
             Assert.InRange(total, 80, 120); // approximate


### PR DESCRIPTION
Five modules had private/internal EstimateTokens(string) wrappers that delegated to PromptGuard.EstimateTokens(). Replaced all call sites with direct calls and removed the wrapper methods. 7 files changed, net -14 lines. 4168 tests pass.