### PR TITLE
docs: update README class table, add unreleased changelog, coverage gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,73 @@ All notable changes to the `prompt-llm-aoi` NuGet package will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **PromptCatalogExporter** — export prompt library to HTML, CSV, and JSON formats
+- **PromptBenchmarkSuite** — benchmark prompt variants against test scenarios
+- **PromptHealthCheck** — library-wide quality analysis and health scoring
+- **PromptChainVisualizer** — Mermaid, DOT, and ASCII flowchart generation from prompt chains
+- **PromptSnapshotManager** — point-in-time library snapshots with diff comparison and rollback
+- **PromptChangeImpactAnalyzer** — blast-radius analysis for prompt template changes
+- **PromptPromotionManager** — lifecycle stage management with approval gates, rollback, and history
+- **PromptCompatibilityChecker** — cross-provider prompt portability analysis
+- **PromptRiskAssessor** — multi-dimensional security risk analysis for prompts
+- **PromptInheritance** — block-based template inheritance with `{{super}}` support
+- **PromptCoverageAnalyzer** — library coverage analysis with health scoring
+- **PromptUsageReport** — comprehensive usage reporting with time-bucketed breakdowns and cost analysis
+- **PromptMatrix** — combinatorial template variable testing
+- **PromptPerformanceProfiler** — execution profiling with percentiles, comparison, and reports
+- **PromptChangelogGenerator** — formatted changelogs from version history with multiple output formats
+- **PromptMarkdownExporter** — export and import prompt libraries as Markdown
+- **PromptSchemaGenerator** — fluent structured output schema builder
+- **PromptQualityGate** — configurable pass/fail gate for prompt validation
+- **PromptSamplerConfig** — LLM sampling parameter builder
+- **PromptSimilarityAnalyzer** — multi-metric prompt comparison and duplicate detection
+- **PromptGoldenTester** — snapshot testing for prompt outputs
+- **PromptScorecardBuilder** — custom evaluation rubrics with weighted scoring
+- **PromptSlotFiller** — structured slot extraction and multi-turn filling
+- **PromptAnnotation** — structured inline comments and metadata for prompts
+- **PromptStyleTransfer** — heuristic prompt tone and style rewriting
+- **PromptReplayRecorder** — VCR-style prompt interaction recording and replay
+- **PromptLinter** — rule-based static analysis for LLM prompts
+- **PromptSplitter** — boundary-aware content chunking for long prompts
+- **PromptDatasetBuilder** — evaluation and fine-tuning dataset builder
+- **PromptMetadataExtractor** — structured prompt analysis for routing and analytics
+- **PromptNegotiator** — iterative prompt refinement with validation feedback loops
+- **PromptDependencyGraph** — DAG analysis for prompt pipelines
+- **PromptSignature** — strongly-typed prompt signatures (DSPy-style)
+- **PromptToolFormatter** — unified tool/function calling format across LLM providers
+- **PromptContextCompressor** — intelligent conversation context compression with 4 strategies
+- **PromptInterpolator** — pipe-based template variable transformations
+- **PromptWorkflow** — DAG-based prompt workflow engine
+- **PromptStreamParser** — real-time streaming content extraction
+- **PromptAuditLog** — immutable hash-chained execution audit trail
+- **PromptRetryPolicy** — configurable retry with backoff, circuit breaker, and error classification
+- **PromptEnsemble** — multi-response aggregation (majority vote, best-of-N, consensus)
+- **PromptOutputValidator** — LLM response validation against configurable rules
+- **PromptChatFormatter** — multi-provider chat message formatting
+- **PromptSanitizer** — prompt cleaning and normalization utility
+- **PromptComplexityScorer** — multi-dimensional prompt complexity analysis
+- **PromptExplainer** — analyze prompts for techniques, sections, and improvement suggestions
+- **PromptFallbackChain** — resilient multi-model execution with automatic fallback
+- **PromptConditional** — conditional logic for prompt templates
+- **PromptContextBuilder** — priority-based prompt context assembly with token budgeting
+- **PromptMigrationAssistant** — cross-provider prompt adaptation assistant
+
+### Fixed
+- Track acquire timestamps to prevent orphaned `RecordCompletion` from corrupting `ConcurrentCount`
+- Resolve stack overflow in `AddToHistory` and add async `ExecuteAsync`
+- Cap retry history to prevent memory leak; fix case-insensitive token escaping
+- `CachingMiddleware` thread-safety and thundering-herd fix
+
+### Changed
+- **Security:** add DoS guards to `PromptInterpolator` filters
+- **Performance:** single-pass `PurgeExpired` eliminates intermediate list allocation
+- **Performance:** optimize `PromptSimilarityAnalyzer` memory and redundant work
+- **Refactor:** unify `RetryPolicy` with `PromptRetryPolicy` to eliminate duplicate backoff/jitter logic
+- **Refactor:** remove 5 redundant `EstimateTokens` wrappers, use `PromptGuard` directly
+
 ## [3.3.0] - 2026-02-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -63,24 +63,96 @@ Send prompts to Azure OpenAI and get responses — with templates, chains, safet
 
 | Class | Description |
 |-------|-------------|
-| [`Main`](#maingettresponseasync) | Single-call Azure OpenAI completions with retries and cancellation |
 | [`Conversation`](#conversation-class) | Multi-turn message history with configurable model parameters |
-| [`PromptTemplate`](#prompttemplate-class) | Reusable `{{variable}}` templates with defaults, validation, and composition |
-| [`PromptChain`](#promptchain-class) | Multi-step LLM pipeline with variable forwarding between steps |
-| `PromptOptions` | Model parameter presets (code generation, creative writing, data extraction, summarization) |
-| `PromptLibrary` | Central template registry with CRUD, search by category/tag, merge, and 8 built-in templates |
-| `PromptGuard` | Injection detection, quality scoring, sanitization, and output format wrapping |
-| `TokenBudget` | Context window management with 3 trim strategies and 15+ model presets |
 | `FewShotBuilder` | Structured few-shot prompt construction with 5 formats and token-budget integration |
-| `PromptVersionManager` | Version history, line-level diffs, and rollback for templates |
+| [`Main`](#maingettresponseasync) | Single-call Azure OpenAI completions with retries and cancellation |
+| `PromptABTester` | A/B testing framework for comparing prompt variant performance |
+| `PromptAnalytics` | Prompt usage analytics and metrics collection |
+| `PromptAnnotation` | Structured inline comments and metadata for prompts |
+| `PromptAuditLog` | Immutable hash-chained execution audit trail |
+| `PromptBatchProcessor` | Batch execution of prompts with concurrency control |
+| `PromptBenchmarkSuite` | Benchmark prompt variants against test scenarios |
+| `PromptCache` | Response caching with configurable expiration policies |
+| `PromptCatalogExporter` | Export prompt library to HTML, CSV, and JSON formats |
+| [`PromptChain`](#promptchain-class) | Multi-step LLM pipeline with variable forwarding between steps |
+| `PromptChainVisualizer` | Mermaid, DOT, and ASCII flowchart generation from prompt chains |
+| `PromptChangeImpactAnalyzer` | Blast-radius analysis for prompt template changes |
+| `PromptChangelogGenerator` | Formatted changelogs from version history with multiple output formats |
+| `PromptChatFormatter` | Multi-provider chat message formatting |
+| `PromptCompatibilityChecker` | Cross-provider prompt portability analysis |
+| `PromptComplexityScorer` | Multi-dimensional prompt complexity analysis |
+| `PromptComplianceChecker` | Policy and regulatory compliance validation for prompts |
 | `PromptComposer` | Fluent structured prompt builder with semantic sections and 4 presets |
-| `PromptRouter` | Intent-based prompt routing with keyword/regex scoring and fallback |
-| `ResponseParser` | Extract JSON, lists, tables, key-value pairs, and code blocks from LLM responses |
-| `PromptTestSuite` | Automated prompt evaluation with 10 assertion types and pluggable response providers |
+| `PromptConditional` | Conditional logic for prompt templates |
+| `PromptContextBuilder` | Priority-based prompt context assembly with token budgeting |
+| `PromptContextCompressor` | Intelligent conversation context compression with 4 strategies |
+| `PromptCostEstimator` | Token-based cost estimation for prompt execution |
+| `PromptCoverageAnalyzer` | Library coverage analysis with health scoring |
+| `PromptDatasetBuilder` | Evaluation and fine-tuning dataset builder |
 | `PromptDebugger` | Deep structural analysis — anti-pattern detection, clarity scoring, suggested fixes |
-| `PromptResponseEvaluator` | Heuristic quality scoring across 5 dimensions (relevance, completeness, etc.) |
-| `PromptGrammarValidator` | Response format validation with 11 rule types (regex, JSON, length, structure) |
+| `PromptDependencyGraph` | DAG analysis for prompt pipelines |
+| `PromptDiff` | Line-level diff comparison between prompt versions |
+| `PromptDocGenerator` | Auto-generate documentation from prompt templates |
+| `PromptEnsemble` | Multi-response aggregation (majority vote, best-of-N, consensus) |
+| `PromptEnvironmentManager` | Environment-specific prompt configuration management |
+| `PromptExplainer` | Analyze prompts for techniques, sections, and improvement suggestions |
+| `PromptFallbackChain` | Resilient multi-model execution with automatic fallback |
+| `PromptFingerprint` | Content-based prompt fingerprinting for deduplication |
 | `PromptFuzzer` | Robustness testing — generates prompt variants via 7 mutation strategies |
+| `PromptGoldenTester` | Snapshot testing for prompt outputs |
+| `PromptGrammarValidator` | Response format validation with 11 rule types (regex, JSON, length, structure) |
+| `PromptGuard` | Injection detection, quality scoring, sanitization, and output format wrapping |
+| `PromptHealthCheck` | Library-wide quality analysis and health scoring |
+| `PromptHistory` | Prompt execution history tracking and retrieval |
+| `PromptInheritance` | Block-based template inheritance with `{{super}}` support |
+| `PromptInterpolator` | Pipe-based template variable transformations |
+| `PromptLibrary` | Central template registry with CRUD, search by category/tag, merge, and 8 built-in templates |
+| `PromptLinter` | Rule-based static analysis for LLM prompts |
+| `PromptLocalizer` | Prompt localization and translation management |
+| `PromptMarkdownExporter` | Export and import prompt libraries as Markdown |
+| `PromptMatrix` | Combinatorial template variable testing |
+| `PromptMerger` | Merge and combine multiple prompt templates |
+| `PromptMetadataExtractor` | Structured prompt analysis for routing and analytics |
+| `PromptMigrationAssistant` | Cross-provider prompt adaptation assistant |
+| `PromptMinifier` | Prompt compression and whitespace optimization |
+| `PromptNegotiator` | Iterative prompt refinement with validation feedback loops |
+| `PromptOptions` | Model parameter presets (code generation, creative writing, data extraction, summarization) |
+| `PromptOutputValidator` | LLM response validation against configurable rules |
+| `PromptPerformanceProfiler` | Execution profiling with percentiles, comparison, and reports |
+| `PromptPipeline` | Configurable prompt processing pipeline with middleware |
+| `PromptPromotionManager` | Lifecycle stage management with approval gates and rollback |
+| `PromptQualityGate` | Configurable pass/fail gate for prompt validation |
+| `PromptRateLimiter` | Request rate limiting and throttling |
+| `PromptRefactorer` | Automated prompt refactoring and optimization suggestions |
+| `PromptReplayRecorder` | VCR-style prompt interaction recording and replay |
+| `PromptResponseEvaluator` | Heuristic quality scoring across 5 dimensions (relevance, completeness, etc.) |
+| `PromptRetryPolicy` | Configurable retry with backoff, circuit breaker, and error classification |
+| `PromptRiskAssessor` | Multi-dimensional security risk analysis for prompts |
+| `PromptRouter` | Intent-based prompt routing with keyword/regex scoring and fallback |
+| `PromptSamplerConfig` | LLM sampling parameter builder |
+| `PromptSanitizer` | Prompt cleaning and normalization utility |
+| `PromptSchemaGenerator` | Fluent structured output schema builder |
+| `PromptScorecardBuilder` | Custom evaluation rubrics with weighted scoring |
+| `PromptSemanticSearch` | Semantic similarity search across prompt libraries |
+| `PromptSignature` | Strongly-typed prompt signatures (DSPy-style) |
+| `PromptSimilarityAnalyzer` | Multi-metric prompt comparison and duplicate detection |
+| `PromptSlotFiller` | Structured slot extraction and multi-turn filling |
+| `PromptSnapshotManager` | Point-in-time library snapshots with diff comparison and rollback |
+| `PromptSplitter` | Boundary-aware content chunking for long prompts |
+| `PromptStreamParser` | Real-time streaming content extraction |
+| `PromptStyleTransfer` | Heuristic prompt tone and style rewriting |
+| [`PromptTemplate`](#prompttemplate-class) | Reusable `{{variable}}` templates with defaults, validation, and composition |
+| `PromptTestSuite` | Automated prompt evaluation with 10 assertion types and pluggable response providers |
+| `PromptTokenOptimizer` | Token usage optimization and prompt compression |
+| `PromptToolFormatter` | Unified tool/function calling format across LLM providers |
+| `PromptUsageReport` | Comprehensive usage reporting with time-bucketed breakdowns and cost analysis |
+| `PromptVariantGenerator` | Automated prompt variant generation for testing |
+| `PromptVersionManager` | Version history, line-level diffs, and rollback for templates |
+| `PromptWorkflow` | DAG-based prompt workflow engine |
+| `ResponseParser` | Extract JSON, lists, tables, key-value pairs, and code blocks from LLM responses |
+| `SerializationGuards` | Input validation and safety checks for deserialization |
+| `StreamChunk` | Typed chunk model for streaming response parsing |
+| `TokenBudget` | Context window management with 3 trim strategies and 15+ model presets |
 
 ## Prerequisites
 

--- a/docs/articles/coverage-gaps.md
+++ b/docs/articles/coverage-gaps.md
@@ -1,0 +1,62 @@
+# Documentation Coverage Gaps
+
+This file tracks features and classes that lack dedicated documentation articles.
+
+## High Priority
+
+These are major features with no corresponding article in `docs/articles/`:
+
+| Feature | Classes | Suggested Article |
+|---------|---------|-------------------|
+| Prompt Debugging & Analysis | `PromptDebugger`, `PromptExplainer`, `PromptComplexityScorer` | `debugging.md` |
+| A/B Testing & Variants | `PromptABTester`, `PromptVariantGenerator`, `PromptMatrix` | `ab-testing.md` |
+| Analytics & Reporting | `PromptAnalytics`, `PromptUsageReport`, `PromptCostEstimator` | `analytics.md` |
+| Prompt Linting & Quality | `PromptLinter`, `PromptQualityGate`, `PromptComplianceChecker` | `linting.md` |
+| Workflow & Pipelines | `PromptWorkflow`, `PromptPipeline`, `PromptDependencyGraph` | `workflows.md` |
+| Streaming | `PromptStreamParser`, `StreamChunk` | `streaming.md` |
+| Template Inheritance | `PromptInheritance`, `PromptConditional`, `PromptInterpolator` | `advanced-templates.md` |
+| Caching & Performance | `PromptCache`, `PromptRateLimiter`, `PromptPerformanceProfiler` | `caching.md` |
+| Snapshot & Promotion | `PromptSnapshotManager`, `PromptPromotionManager` | `lifecycle.md` |
+| Resilience | `PromptFallbackChain`, `PromptRetryPolicy`, `PromptEnsemble` | `resilience.md` |
+
+## Medium Priority
+
+| Feature | Classes | Suggested Article |
+|---------|---------|-------------------|
+| Export & Import | `PromptCatalogExporter`, `PromptMarkdownExporter`, `PromptDocGenerator` | `export.md` |
+| Audit & Replay | `PromptAuditLog`, `PromptReplayRecorder`, `PromptHistory` | `auditing.md` |
+| Schema & Validation | `PromptSchemaGenerator`, `PromptOutputValidator`, `PromptGrammarValidator` | `validation.md` |
+| Risk & Security | `PromptRiskAssessor`, `PromptSanitizer`, `PromptFingerprint` | `risk-assessment.md` |
+| Cross-Provider | `PromptCompatibilityChecker`, `PromptMigrationAssistant`, `PromptChatFormatter` | `cross-provider.md` |
+| Scoring & Evaluation | `PromptScorecardBuilder`, `PromptResponseEvaluator`, `PromptGoldenTester`, `PromptBenchmarkSuite` | `evaluation.md` |
+
+## Low Priority
+
+| Feature | Classes | Suggested Article |
+|---------|---------|-------------------|
+| Prompt Utilities | `PromptMinifier`, `PromptSplitter`, `PromptMerger`, `PromptTokenOptimizer` | `utilities.md` |
+| Context Management | `PromptContextBuilder`, `PromptContextCompressor` | `context.md` |
+| Metadata & Search | `PromptMetadataExtractor`, `PromptSemanticSearch`, `PromptSimilarityAnalyzer` | `search.md` |
+| Slot Filling & Negotiation | `PromptSlotFiller`, `PromptNegotiator` | `interactive.md` |
+| Signatures & Formatting | `PromptSignature`, `PromptToolFormatter`, `PromptStyleTransfer` | `formatting.md` |
+| Annotations & Datasets | `PromptAnnotation`, `PromptDatasetBuilder` | `datasets.md` |
+| Visualization | `PromptChainVisualizer`, `PromptChangeImpactAnalyzer` | `visualization.md` |
+| Changelog & Diff | `PromptChangelogGenerator`, `PromptDiff`, `PromptRefactorer` | `changelog.md` |
+
+## Existing Coverage
+
+The following topics are covered by current articles:
+
+- Getting started → `getting-started.md`
+- Templates → `templates.md`
+- Chains → `chains.md`
+- Conversations → `conversations.md`
+- Options & configuration → `options.md`
+- Safety & guards → `safety.md`
+- Testing → `testing.md`
+- Error handling → `error-handling.md`
+- Architecture → `architecture.md`
+- Advanced features → `advanced-features.md`
+- Production features → `production-features.md`
+- Migration → `migration.md`
+- Security hardening → `security-hardening.md`


### PR DESCRIPTION
## Changes
1. **README.md** ΓÇö Updated Full Class Library table to include all 91 .cs files in src/
2. **CHANGELOG.md** ΓÇö Added [Unreleased] section documenting classes added since 3.3.0
3. **docs/articles/coverage-gaps.md** ΓÇö New file identifying ~26 documentation gaps organized by priority (High/Medium/Low)