### PR TITLE
refactor: use Dictionary index for O(1) batch item lookups

### DIFF
--- a/src/PromptBatchProcessor.cs
+++ b/src/PromptBatchProcessor.cs
@@ -399,6 +399,7 @@ namespace Prompt
     public class PromptBatchProcessor
     {
         private readonly List<BatchItem> _items = new();
+        private readonly Dictionary<string, BatchItem> _itemIndex = new(StringComparer.Ordinal);
         private readonly object _lock = new();
         private Action<BatchProgress>? _progressCallback;
         private Func<string, string?>? _processFunc;
@@ -445,10 +446,12 @@ namespace Prompt
                 if (_items.Count >= MaxBatchSize)
                     throw new InvalidOperationException(
                         $"Batch size cannot exceed {MaxBatchSize} items.");
-                if (_items.Any(i => i.Id == id))
+                if (_itemIndex.ContainsKey(id))
                     throw new ArgumentException(
                         $"An item with ID '{id}' already exists in the batch.", nameof(id));
-                _items.Add(new BatchItem(id, template, variables, tags));
+                var item = new BatchItem(id, template, variables, tags);
+                _items.Add(item);
+                _itemIndex[id] = item;
             }
             return this;
         }
@@ -548,7 +551,11 @@ namespace Prompt
         /// </summary>
         public void Clear()
         {
-            lock (_lock) _items.Clear();
+            lock (_lock)
+            {
+                _items.Clear();
+                _itemIndex.Clear();
+            }
         }
 
         /// <summary>
@@ -624,7 +631,7 @@ namespace Prompt
         public BatchItem? ProcessSingle(string id)
         {
             BatchItem? item;
-            lock (_lock) item = _items.FirstOrDefault(i => i.Id == id);
+            lock (_lock) _itemIndex.TryGetValue(id, out item);
             if (item == null) return null;
 
             ProcessSingleItem(item);
@@ -638,7 +645,11 @@ namespace Prompt
         /// <returns>The batch item, or null if not found.</returns>
         public BatchItem? GetItem(string id)
         {
-            lock (_lock) return _items.FirstOrDefault(i => i.Id == id);
+            lock (_lock)
+            {
+                _itemIndex.TryGetValue(id, out var item);
+                return item;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Replace O(n) linear scans in \PromptBatchProcessor\ with a \Dictionary<string, BatchItem>\ index for ID-based operations.

### Changes
- Added \_itemIndex\ dictionary alongside the existing \_items\ list
- \AddItem\: duplicate check is now O(1) via \ContainsKey\ instead of O(n) \Any()\
- \ProcessSingle\: O(1) \TryGetValue\ instead of O(n) \FirstOrDefault\
- \GetItem\: O(1) \TryGetValue\ instead of O(n) \FirstOrDefault\
- \Clear\: clears both collections

### Impact
For batches approaching the 10,000 item limit, this eliminates quadratic behavior in AddItem (each add was scanning all existing items) and makes lookups constant-time.